### PR TITLE
PZ-101, PZ-106, PZ-124 | Copying/Moving files into an empty directory should be possible; Right-click functionality outside of an archive entry should yield certain general archive functionality; Add empty directory should be possible

### DIFF
--- a/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveService.java
+++ b/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveService.java
@@ -212,6 +212,18 @@ public class CommonsCompressArchiveService implements ArchiveWriteService {
                                                 e.getMessage()));
                 }
             }
+            else {
+                File file = new File((String) f.getAdditionalInfoMap()
+                                               .get(KEY_FILE_PATH));
+                if (file.exists()) {
+                    ArchiveEntry entry =
+                            aoStream.createArchiveEntry(file, f.getFileName());
+                    prepareArchiveEntry(entry, f);
+                    aoStream.putArchiveEntry(entry);
+                    aoStream.closeArchiveEntry();
+                    aoStream.flush();
+                }
+            }
         }
 
         DEFAULT_BUS.post(new ProgressMessage(sessionId, PROGRESS,

--- a/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
+++ b/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
@@ -301,6 +301,12 @@ ctxMenu.copy.text=Copy
 ctxMenu.move.text=Move
 ctxMenu.info.text=File Info
 ctxMenu.delete.text=Delete
+
+tblCtxMenu.paste.text=Paste
+tblCtxMenu.drop.text=Drop
+tblCtxMenu.add-file.text=Add File
+tblCtxMenu.add-dir.text=Add Directory
+
 license.tblLicenseInfo.canonicalName.text=Canonical Name
 license.tblLicenseInfo.version.text=Version
 license.tblLicenseInfo.licenseType.text=License Type

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnAddDirEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnAddDirEventHandler.java
@@ -21,9 +21,11 @@ import org.apache.logging.log4j.core.LoggerContext;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.KEY_FILE_PATH;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
@@ -68,6 +70,14 @@ public class BtnAddDirEventHandler implements EventHandler<ActionEvent> {
             JFXUtil.executeBackgroundProcess(sessionId, (Stage) fileContentsView.getScene().getWindow(),
                                              ()-> {
                     List<FileInfo> files = ArchiveUtil.handleDirectory(prefix, dirPath.getParent(), dirPath, depth+1, index);
+                    files.add(new FileInfo((index+1), depth,
+                                            dirPath.getFileName().toString(),
+                                            -1, 0,
+                                            0, null,
+                                            null, null,
+                                            "", "", 0, "",
+                                            true, false,
+                                            Collections.singletonMap(KEY_FILE_PATH, dirPath.toString())));
                     archiveWriteService.addFile(sessionId, fxArchiveInfo.getArchivePath(),
                                                 files.toArray(new FileInfo[0]));
                 },

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
@@ -29,11 +29,14 @@ import org.apache.logging.log4j.core.LoggerContext;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_BUNDLE;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
+import static com.ntak.pearlzip.ui.model.ZipState.CONTEXT_MENU_INSTANCES;
+import static com.ntak.pearlzip.ui.model.ZipState.ROW_TRIGGER;
 import static com.ntak.pearlzip.ui.util.ArchiveUtil.launchMainStage;
 import static com.ntak.pearlzip.ui.util.JFXUtil.isFileInArchiveLevel;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
@@ -61,6 +64,10 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
 
     @Override
     public void handle(MouseEvent event) {
+            if (Objects.nonNull(row.getItem())) {
+                ROW_TRIGGER.set(true);
+            }
+
             if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY
                     && event.getClickCount() == 2) {
 
@@ -166,6 +173,11 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
                     ContextMenuController controller = loader.getController();
                     controller.initData(fxArchiveInfo, row);
                     root.show(row, event.getScreenX(), event.getScreenY());
+                    synchronized(CONTEXT_MENU_INSTANCES) {
+                        CONTEXT_MENU_INSTANCES.forEach(ContextMenu::hide);
+                        CONTEXT_MENU_INSTANCES.clear();
+                        CONTEXT_MENU_INSTANCES.add(root);
+                    }
                 } catch (Exception e) {
 
                 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
@@ -7,10 +7,13 @@ import com.ntak.pearlzip.archive.pub.ArchiveReadService;
 import com.ntak.pearlzip.archive.pub.ArchiveService;
 import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
 import com.ntak.pearlzip.license.model.LicenseInfo;
+import javafx.scene.control.ContextMenu;
 import org.apache.logging.log4j.util.Strings;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
@@ -23,6 +26,8 @@ public class ZipState {
 
     public static final int WIDTH = Integer.parseInt(System.getProperty(CNS_WINDOW_WIDTH, "816"));
     public static final int HEIGHT = Integer.parseInt(System.getProperty(CNS_WINDOW_HEIGHT, "480"));
+    public static final AtomicBoolean ROW_TRIGGER = new AtomicBoolean(false);
+    public static final CopyOnWriteArrayList<ContextMenu> CONTEXT_MENU_INSTANCES = new CopyOnWriteArrayList<>();
 
     private static final List<ArchiveWriteService> WRITE_PROVIDERS = new LinkedList<>();
     private static final List<ArchiveReadService> READ_PROVIDERS = new LinkedList<>();

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/TableContextMenuController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/TableContextMenuController.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021 92AK
+ */
+package com.ntak.pearlzip.ui.pub;
+
+import com.ntak.pearlzip.archive.pub.FileInfo;
+import com.ntak.pearlzip.ui.event.handler.BtnAddDirEventHandler;
+import com.ntak.pearlzip.ui.event.handler.BtnAddFileEventHandler;
+import com.ntak.pearlzip.ui.event.handler.BtnCopySelectedEventHandler;
+import com.ntak.pearlzip.ui.event.handler.BtnMoveSelectedEventHandler;
+import com.ntak.pearlzip.ui.model.FXArchiveInfo;
+import com.ntak.pearlzip.ui.model.FXMigrationInfo;
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableView;
+
+import static com.ntak.pearlzip.ui.model.ZipState.ROW_TRIGGER;
+
+/**
+ *  Controller for the Table Context Menu.
+ *  @author Aashutos Kakshepati
+ */
+public class TableContextMenuController {
+
+    @FXML
+    public ContextMenu tblCtxMenu;
+    @FXML
+    private MenuItem mnuPaste;
+    @FXML
+    private MenuItem mnuDrop;
+    @FXML
+    private MenuItem mnuAddFile;
+    @FXML
+    private MenuItem mnuAddDir;
+
+    public void initData(FXArchiveInfo archiveInfo) {
+        mnuPaste.setVisible(false);
+        mnuDrop.setVisible(false);
+
+        if (archiveInfo.getMigrationInfo().getType() == FXMigrationInfo.MigrationType.COPY) {
+            mnuPaste.setVisible(true);
+        }
+
+        if (archiveInfo.getMigrationInfo().getType() == FXMigrationInfo.MigrationType.MOVE) {
+            mnuDrop.setVisible(true);
+        }
+
+        FrmMainController controller;
+        if (archiveInfo.getController().isPresent()) {
+            controller = archiveInfo.getController().get();
+            TableView<FileInfo> fileContentsView = controller.getFileContentsView();
+            mnuDrop.setOnAction((e) -> {
+                try {
+                    Platform.runLater(() ->
+                    new BtnMoveSelectedEventHandler(fileContentsView,
+                                                    controller.getBtnCopy(),
+                                                    controller.getBtnMove(),
+                                                    controller.getBtnDelete(),
+                                                    archiveInfo).handle(e));
+                } finally {
+                    ROW_TRIGGER.set(false);
+                }
+            });
+            mnuPaste.setOnAction((e) -> {
+                try {
+                    Platform.runLater(() -> new BtnCopySelectedEventHandler(fileContentsView,
+                                                                            controller.getBtnCopy(),
+                                                                            controller.getBtnMove(),
+                                                                            controller.getBtnDelete(),
+                                                                            archiveInfo).handle(e));
+                } finally {
+                    ROW_TRIGGER.set(false);
+                }
+            }
+            );
+
+            mnuAddFile.setOnAction(e-> {
+                try {
+                    new BtnAddFileEventHandler(fileContentsView, archiveInfo).handle(e);
+                } finally {
+                    ROW_TRIGGER.set(false);
+                }
+            });
+            mnuAddDir.setOnAction(e-> {
+                try {
+                    new BtnAddDirEventHandler(fileContentsView, archiveInfo).handle(e);
+                } finally {
+                    ROW_TRIGGER.set(false);
+                }
+            });
+        }
+    }
+
+}

--- a/pearl-zip-ui/src/main/resources/tablecontextmenu.fxml
+++ b/pearl-zip-ui/src/main/resources/tablecontextmenu.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2021 92AK
+  -->
+
+<?import javafx.scene.control.*?>
+<ContextMenu fx:id="tblCtxMenu" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.ntak.pearlzip.ui.pub.TableContextMenuController">
+  <items>
+      <MenuItem fx:id="mnuPaste" mnemonicParsing="false" text="%tblCtxMenu.paste.text" />
+      <MenuItem fx:id="mnuDrop" mnemonicParsing="false" text="%tblCtxMenu.drop.text" />
+      <MenuItem fx:id="mnuAddFile" mnemonicParsing="false" text="%tblCtxMenu.add-file.text" />
+      <MenuItem fx:id="mnuAddDir" mnemonicParsing="false" text="%tblCtxMenu.add-dir.text" />
+  </items>
+</ContextMenu>

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AddToArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AddToArchiveTestFX.java
@@ -36,6 +36,8 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
      * + Add symbolic soft link file to zip archive
      * + Add symbolic hard link file and document file to tar archive
      * + Add image file to jar archive
+     * + Table context menu Add File
+     * + Table context menu Add Directory
      */
 
     @BeforeEach
@@ -48,7 +50,7 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
         super.tearDown();
         for (Path dir :
                 Files.list(dir.getParent().getParent()).filter(p->p.getFileName().toString().startsWith("pz")).collect(
-                        Collectors.toList())) {
+                        Collectors.toSet())) {
             UITestSuite.clearDirectory(dir);
         }
     }
@@ -60,7 +62,17 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
         final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
 
         final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
-        simAddDirectoryToNewNonCompressorArchive(this, archive, dir);
+        simAddDirectoryToNewNonCompressorArchive(this, archive, dir, false);
+    }
+
+    @Test
+    @DisplayName("Test: Add folder using context menu to zip archive and verify contents")
+    public void testFX_AddFolderCtxMenuToZipArchive_MatchExpectations() throws IOException {
+        final String archiveFormat = "zip";
+        final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
+
+        final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
+        simAddDirectoryToNewNonCompressorArchive(this, archive, dir, true);
     }
 
     @Test
@@ -70,7 +82,7 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
         final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
 
         final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
-        simAddDirectoryToNewNonCompressorArchive(this, archive, dir);
+        simAddDirectoryToNewNonCompressorArchive(this, archive, dir, false);
     }
 
     @Test
@@ -80,7 +92,7 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
         final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
 
         final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
-        simAddDirectoryToNewNonCompressorArchive(this, archive, dir);
+        simAddDirectoryToNewNonCompressorArchive(this, archive, dir, false);
     }
 
     @Test
@@ -154,6 +166,37 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
 
             Assertions.assertEquals(sourceHash, targetHash, "File hashes were not identical");
         }
+    }
+
+    @Test
+    @DisplayName("Test: Add image file using context menu to tar archive and verify contents")
+    public void testFX_AddImageFileCtxMenuToZipArchive_MatchExpectations() throws IOException {
+        final String archiveFormat = "jar";
+        final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
+
+        Path file = Paths.get("src", "test", "resources", "img.png").toAbsolutePath();
+        final long sourceHash = CompressUtil.crcHashFile(file.toFile());
+        final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
+        simNewArchive(this, archive);
+        simAddFile(this, file, true, archiveName);
+
+        TableView<FileInfo> fileContentsView = FormUtil.lookupNode(s->s.getTitle().contains(archiveName),
+                                                                   "#fileContentsView");
+        final List<String> files = fileContentsView.getItems()
+                                                   .stream()
+                                                   .map(FileInfo::getFileName)
+                                                   .collect(Collectors.toList());
+        Assertions.assertTrue(files.contains("img.png"),
+                              "Image was not found in archive");
+
+        // Extract file and check consistency
+        Path targetFile = Paths.get(dir.getParent().toAbsolutePath().toString(), file.getFileName().toString()).toAbsolutePath();
+        FormUtil.selectTableViewEntry(this, fileContentsView,
+                                      FileInfo::getFileName, file.getFileName().toString());
+        simExtractFile(this, targetFile);
+        final long targetHash = CompressUtil.crcHashFile(targetFile.toFile());
+
+        Assertions.assertEquals(sourceHash, targetHash, "File hashes were not identical");
     }
 
     @Test

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/MoveInArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/MoveInArchiveTestFX.java
@@ -3,10 +3,13 @@
  */
 package com.ntak.pearlzip.ui.testfx;
 
+import com.ntak.pearlzip.archive.pub.FileInfo;
 import com.ntak.pearlzip.ui.UITestSuite;
 import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import com.ntak.pearlzip.ui.util.AbstractPearlZipTestFX;
+import com.ntak.testfx.FormUtil;
 import javafx.scene.control.DialogPane;
+import javafx.scene.control.TableView;
 import javafx.scene.input.MouseButton;
 import org.junit.jupiter.api.*;
 
@@ -26,6 +29,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class MoveInArchiveTestFX extends AbstractPearlZipTestFX {
 
     private static Path dir;
+    private static Path emptyDir;
 
    /*
     *  Test cases:
@@ -35,11 +39,15 @@ public class MoveInArchiveTestFX extends AbstractPearlZipTestFX {
     *  + Move cancel
     *  + Move no file selected
     *  + Move folder fail
+    *  + Table context menu drop
+    *  + Move into empty folder
     */
 
     @BeforeEach
     public void setUp() throws IOException {
         dir = genSourceDataSet();
+        emptyDir = Paths.get(dir.toAbsolutePath().getParent().toString(), "empty-dir");
+        Files.createDirectories(emptyDir);
     }
 
     @AfterEach
@@ -79,6 +87,40 @@ public class MoveInArchiveTestFX extends AbstractPearlZipTestFX {
         Assertions.assertEquals(1,
                                 info.getFiles().stream().filter(f->f.getFileName().equals(Paths.get("root", "level1c"
                                         , "level1c1", "level2b", "MOVE_DOWN.txt").toString())).count(),
+                                "File was not moved");
+    }
+
+    @Test
+    @DisplayName("Test: Move file by table context menu and button in application within a zip archive successfully")
+    public void testFX_moveFileByTableContextMenuAndButtonZip_MatchExpectations() throws IOException {
+        final String archiveFormat = "zip";
+        final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
+
+        final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
+
+        // Create archive of the appropriate format and add folder to archive...
+        simNewArchive(this, archive);
+        Assertions.assertTrue(lookupArchiveInfo(archiveName).isPresent(), "Archive is not open in PearlZip");
+        simAddFolder(this, dir);
+
+        Path file = Paths.get("root", "level1c", "level1c1", "level2b", "MOVE_UP.txt");
+
+        final String tableName = "#fileContentsView";
+        TableView<FileInfo> fileContentsView = FormUtil.lookupNode(s->s.getTitle().contains(archiveName),
+                                                                   "#fileContentsView");
+        simTraversalArchive(this, archiveName, tableName, (r)->{}, SSV.split(file.toString()));
+        clickOn("#btnMove");
+        clickOn("#mnuMoveSelected");
+        simUp(this);
+
+        clickOn(fileContentsView, MouseButton.SECONDARY);
+        sleep(50, MILLISECONDS);
+        clickOn("#mnuDrop");
+        sleep(50, MILLISECONDS);
+
+        FXArchiveInfo info = lookupArchiveInfo(archiveName).get();
+        Assertions.assertEquals(1,
+                                info.getFiles().stream().filter(f->f.getFileName().equals(Paths.get("root", "level1c", "level1c1", "MOVE_UP.txt").toString())).count(),
                                 "File was not moved");
     }
 
@@ -367,5 +409,53 @@ public class MoveInArchiveTestFX extends AbstractPearlZipTestFX {
 
         DialogPane dialogPane = lookup(".dialog-pane").query();
         Assertions.assertTrue(dialogPane.getContentText().startsWith("Move could not be initiated"), "The text in warning dialog was not matched as expected");
+    }
+
+    @Test
+    @DisplayName("Test: Move file into empty directory")
+    public void testFX_moveFileIntoEmptyDirectory_Success() throws IOException {
+        final String archiveFormat = "jar";
+        final String archiveName = String.format("test%s.%s", archiveFormat, archiveFormat);
+
+        final Path archive = Paths.get(System.getProperty("user.home"), ".pz", "temp", archiveName);
+
+        // Create archive of the appropriate format and add folder to archive...
+        simNewArchive(this, archive);
+        Assertions.assertTrue(lookupArchiveInfo(archiveName).isPresent(), "Archive is not open in PearlZip");
+        simAddFolder(this, dir);
+        simAddFolder(this, emptyDir);
+
+        Path file = Paths.get("root", "level1c", "level1c1", "level2b", "MOVE_UP.txt");
+
+        final String tableName = "#fileContentsView";
+        simTraversalArchive(this, archiveName, tableName, (r)->{}, SSV.split(file.toString()));
+        clickOn("#btnMove");
+        sleep(5, MILLISECONDS);
+        clickOn("#mnuMoveSelected");
+        sleep(5, MILLISECONDS);
+        simUp(this);
+        sleep(5, MILLISECONDS);
+        simUp(this);
+        sleep(5, MILLISECONDS);
+        simUp(this);
+        sleep(5, MILLISECONDS);
+        simUp(this);
+        sleep(5, MILLISECONDS);
+        simTraversalArchive(this, archiveName, tableName, this::doubleClickOn, "empty-dir");
+        TableView<FileInfo> fileContentsView = FormUtil.lookupNode(s->s.getTitle().contains(archiveName),
+                                                                   tableName);
+        clickOn(fileContentsView, MouseButton.SECONDARY);
+        sleep(5, MILLISECONDS);
+        clickOn("#mnuDrop");
+        sleep(5, MILLISECONDS);
+
+        FXArchiveInfo info = lookupArchiveInfo(archiveName).get();
+        Assertions.assertEquals(1,
+                                info.getFiles().stream().filter(f->f.getFileName().equals(Paths.get("empty-dir",
+                                                                                                    "MOVE_UP.txt").toString())).count(),
+                                "File was not moved");
+        Assertions.assertEquals(1,
+                                info.getFiles().stream().filter(f->f.getFileName().endsWith("MOVE_UP.txt")).count(),
+                                "File was not moved, may have been copied unexpectedly");
     }
 }

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
@@ -83,29 +83,64 @@ public class PearlZipFXUtil {
         Assertions.assertTrue(Files.exists(archive), "Archive was not created");
     }
 
+    public static void simAddFolder(FxRobot robot, Path folder, boolean useContextMenu, String archiveName) {
+        if (!useContextMenu) {
+            robot.clickOn("#btnAdd", MouseButton.PRIMARY);
+            robot.sleep(50, MILLISECONDS);
+
+            robot.clickOn("#mnuAddDir", MouseButton.PRIMARY);
+            robot.sleep(50, MILLISECONDS);
+
+            NativeFileChooserUtil.chooseFolder(PLATFORM, robot, folder);
+            robot.sleep(50, MILLISECONDS);
+        } else {
+            TableView<FileInfo> fileContentsView = FormUtil.lookupNode(s->s.getTitle().contains(archiveName),
+                                                                       "#fileContentsView");
+            robot.clickOn(fileContentsView, MouseButton.SECONDARY);
+            robot.sleep(50, MILLISECONDS);
+
+            robot.clickOn("#mnuAddDir");
+            robot.sleep(50, MILLISECONDS);
+
+            NativeFileChooserUtil.chooseFolder(PLATFORM, robot, folder);
+            robot.sleep(50, MILLISECONDS);
+        }
+    }
+
     public static void simAddFolder(FxRobot robot, Path folder) {
-        robot.clickOn("#btnAdd", MouseButton.PRIMARY);
-        robot.sleep(50, MILLISECONDS);
-
-        robot.clickOn("#mnuAddDir", MouseButton.PRIMARY);
-        robot.sleep(50, MILLISECONDS);
-
-        NativeFileChooserUtil.chooseFolder(PLATFORM, robot, folder);
-        robot.sleep(50, MILLISECONDS);
+        simAddFolder(robot, folder, false, null);
     }
 
     public static void simAddFile(FxRobot robot, Path file) {
-        robot.clickOn("#btnAdd", MouseButton.PRIMARY);
-        robot.sleep(50, MILLISECONDS);
-
-        robot.clickOn("#mnuAddFile", MouseButton.PRIMARY);
-        robot.sleep(50, MILLISECONDS);
-
-        chooseFile(PLATFORM, robot, file);
-        robot.sleep(50, MILLISECONDS);
+        simAddFile(robot, file, false, null);
     }
 
-    public static void simAddDirectoryToNewNonCompressorArchive(FxRobot robot, Path archive, Path dir) throws IOException {
+    public static void simAddFile(FxRobot robot, Path file, boolean useContextMenu, String archiveName) {
+        if (!useContextMenu) {
+            robot.clickOn("#btnAdd", MouseButton.PRIMARY);
+            robot.sleep(50, MILLISECONDS);
+
+            robot.clickOn("#mnuAddFile", MouseButton.PRIMARY);
+            robot.sleep(50, MILLISECONDS);
+
+            chooseFile(PLATFORM, robot, file);
+            robot.sleep(50, MILLISECONDS);
+        } else {
+            TableView<FileInfo> fileContentsView = FormUtil.lookupNode(s->s.getTitle().contains(archiveName),
+                                                                       "#fileContentsView");
+            robot.clickOn(fileContentsView, MouseButton.SECONDARY);
+            robot.sleep(50, MILLISECONDS);
+
+            robot.clickOn("#mnuAddFile");
+            robot.sleep(50, MILLISECONDS);
+
+            NativeFileChooserUtil.chooseFile(PLATFORM, robot, file);
+            robot.sleep(50, MILLISECONDS);
+        }
+    }
+
+    public static void simAddDirectoryToNewNonCompressorArchive(FxRobot robot, Path archive, Path dir,
+            boolean useContextMenu) throws IOException {
         // Generate expectations from directory to be added...
         Map<Integer,Map<String,String[]>> expectations = genArchiveContentsExpectationsAuto(dir);
         String archiveName = archive.getFileName().toString();
@@ -113,7 +148,7 @@ public class PearlZipFXUtil {
         // Create archive of the appropriate format and add folder to archive...
         simNewArchive(robot, archive);
         Assertions.assertTrue(lookupArchiveInfo(archiveName).isPresent(), "Archive is not open in PearlZip");
-        simAddFolder(robot, dir);
+        simAddFolder(robot, dir, useContextMenu, archiveName);
 
         checkArchiveFileHierarchy(robot, expectations, archiveName);
     }


### PR DESCRIPTION
+ Implemented functionality to allow addition of folder zip entries
+ Implemented functionality to spawn context menu in archive viewer outside of row selection
+ Updated/Implemented TestFX unit tests
+ Updated/Implemented required TestFX utility methods

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>