### PR TITLE
PZ-96 | Temporary files should have unique names

### DIFF
--- a/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveReadService.java
+++ b/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveReadService.java
@@ -36,7 +36,8 @@ import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 /**
  *   Implementation of an Archive Read Service, which utilises the Apache Commons Compress library underneath for
  *   the tar format. PAX headers are supported intrinsically for long file names.
- *  @author Aashutos Kakshepati
+ *
+ *   @author Aashutos Kakshepati
  */
 public class CommonsCompressArchiveReadService implements ArchiveReadService {
 

--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ConfigurationConstants.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ConfigurationConstants.java
@@ -25,5 +25,5 @@ public class ConfigurationConstants {
 
 
     public static final String TMP_DIR_PREFIX = System.getProperty(CNS_TMP_DIR_PREFIX,"pz");
-
+    public static final String REGEX_TIMESTAMP_DIR = "pz\\d{13}";
 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnCopySelectedEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnCopySelectedEventHandler.java
@@ -28,7 +28,7 @@ import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.TMP_DIR
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.COMPLETED;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
-import static com.ntak.pearlzip.ui.util.ArchiveUtil.createBackupArchive;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.*;
 import static com.ntak.pearlzip.ui.util.JFXUtil.changeButtonPicText;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -211,10 +211,8 @@ public class BtnCopySelectedEventHandler implements EventHandler<ActionEvent> {
                                                                                                                    .size());
 
                                                               if (!successCopy) {
-                                                                  Files.copy(tempArchive,
-                                                                             Paths.get(fxArchiveInfo.getArchivePath()),
-                                                                             REPLACE_EXISTING);
-                                                                  Files.deleteIfExists(tempArchive);
+                                                                  restoreBackupArchive(tempArchive,
+                                                                                       Paths.get(fxArchiveInfo.getArchivePath()));
 
                                                                   // LOG: Issue adding file %s to archive %s
                                                                   LOGGER.error(resolveTextKey(
@@ -227,6 +225,7 @@ public class BtnCopySelectedEventHandler implements EventHandler<ActionEvent> {
                                                                           fxArchiveInfo.getArchivePath()));
 
                                                               }
+                                                              removeBackupArchive(tempArchive);
                                                           },
                                                      (s) -> {
                                                               // finally: clear Migration Info, Enable move and delete button, update Copy button look

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnDeleteEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnDeleteEventHandler.java
@@ -32,9 +32,8 @@ import static com.ntak.pearlzip.archive.constants.LoggingConstants.LBL_PROGRESS_
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.PROGRESS;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
-import static com.ntak.pearlzip.ui.util.ArchiveUtil.createBackupArchive;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.*;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static javafx.scene.control.ProgressIndicator.INDETERMINATE_PROGRESS;
 
 /**
@@ -108,11 +107,11 @@ public class BtnDeleteEventHandler implements EventHandler<MouseEvent> {
                             ArchiveService.DEFAULT_BUS.post(new ProgressMessage(sessionId, PROGRESS,
                                                                                 resolveTextKey(LBL_PROGRESS_LOADING),
                                                                                 INDETERMINATE_PROGRESS, 1));
-                            Files.copy(tempArchive.get(), Paths.get(fxArchiveInfo.getArchivePath()), REPLACE_EXISTING);
-                            Files.deleteIfExists(tempArchive.get());
+                            restoreBackupArchive(tempArchive.get(), Paths.get(fxArchiveInfo.getArchivePath()));
                         }
                     } finally {
                         fxArchiveInfo.getMigrationInfo().clear();
+                        removeBackupArchive(tempArchive.get());
                     }
                },
                                              (s)->{

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnMoveSelectedEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnMoveSelectedEventHandler.java
@@ -29,7 +29,7 @@ import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.KEY_FIL
 import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.TMP_DIR_PREFIX;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
-import static com.ntak.pearlzip.ui.util.ArchiveUtil.createBackupArchive;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.*;
 import static com.ntak.pearlzip.ui.util.JFXUtil.changeButtonPicText;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -181,8 +181,8 @@ public class BtnMoveSelectedEventHandler implements EventHandler<ActionEvent> {
                                                                                                                                                      .getFile());
 
                                                               if (!success) {
-                                                                  Files.copy(tempArchive, Paths.get(fxArchiveInfo.getArchivePath()), REPLACE_EXISTING);
-                                                                  Files.deleteIfExists(tempArchive);
+                                                                  restoreBackupArchive(tempArchive,
+                                                                                       Paths.get(fxArchiveInfo.getArchivePath()));
 
                                                                   // LOG: Issue adding file %s to archive %s
                                                                   LOGGER.error(resolveTextKey(LOG_ISSUE_ADDING_FILE_FOR_COPY, fileName.toString(),
@@ -190,6 +190,7 @@ public class BtnMoveSelectedEventHandler implements EventHandler<ActionEvent> {
                                                                   throw new IOException(resolveTextKey(LOG_ISSUE_ADDING_FILE_FOR_COPY, fileName.toString(),
                                                                                                        fxArchiveInfo.getArchivePath()));
                                                               }
+                                                              removeBackupArchive(tempArchive);
                                                           },
                                                           (e)->{
                                                               // LOG: Issue occurred on pasting migration item (root item: %s). Migration has been cancelled.

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/ConfirmCloseEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/ConfirmCloseEventHandler.java
@@ -32,6 +32,7 @@ import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.KEY_FIL
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
 import static com.ntak.pearlzip.ui.util.ArchiveUtil.addToRecentFile;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.removeBackupArchive;
 import static com.ntak.pearlzip.ui.util.JFXUtil.raiseAlert;
 
 /**
@@ -82,8 +83,8 @@ public class ConfirmCloseEventHandler implements EventHandler<WindowEvent> {
                             // If compressor - create new archive with nested file. replace existing archive.
                             if (ZipState.getCompressorArchives().contains(fxArchiveInfo.getParentPath().substring(fxArchiveInfo.getParentPath().lastIndexOf(".")+1))) {
                                 long sessionId = System.currentTimeMillis();
-                                Path parentTempArchive = Paths.get(LOCAL_TEMP.toString(),
-                                                             Paths.get(parentPath).getFileName().toString());
+                                Path parentTempArchive = Paths.get(LOCAL_TEMP.toString(), String.format("pz%d", sessionId),
+                                                                   Paths.get(fxArchiveInfo.getArchivePath()).getFileName().toString());
                                 JFXUtil.executeBackgroundProcess(sessionId, stage,
                                                                  () -> archiveWriteService.createArchive(sessionId,
                                                                                                          parentTempArchive.toString(),
@@ -154,7 +155,7 @@ public class ConfirmCloseEventHandler implements EventHandler<WindowEvent> {
                         }
                     }
                 }
-                Files.delete(tempArchive);
+                removeBackupArchive(tempArchive);
             }
         } catch(IOException e) {
             // Issue with IO Process when saving down archive %s

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
@@ -81,9 +81,11 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
                                                              .getWindow();
                 // Extract tar ball into temp location from wrapped zip
                 final Path nestedArchive = Paths.get(STORE_TEMP.toAbsolutePath()
-                                                               .toString(),
+                                                               .toString(), String.format("pz%d",
+                                                                                          sessionId),
                                                      selectedFile
                                                              .getFileName().toString());
+
                 if (ZipState.supportedReadArchives().stream().anyMatch(e -> clickedRow.getFileName().endsWith(String.format(".%s", e)))) {
                     JFXUtil.executeBackgroundProcess(sessionId, thisStage,
                                                      ()-> {
@@ -92,9 +94,10 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
                                                          // LOG: An archive which can be extracted...
                                                          LOGGER.debug(resolveTextKey(LOG_ARCHIVE_CAN_EXTRACT));
 
+                                                         Files.createDirectories(nestedArchive.getParent());
                                                          Files.deleteIfExists(nestedArchive);
                                                          ArchiveReadService archiveService =
-                                                                 ZipState.getReadArchiveServiceForFile(clickedRow.getFileName())
+                                                                 ZipState.getReadArchiveServiceForFile(fxArchiveInfo.getArchivePath())
                                                                          .get();
                                                          archiveService.extractFile(sessionId, nestedArchive,
                                                                                     fxArchiveInfo.getArchivePath(),

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
@@ -31,17 +31,13 @@ import org.apache.logging.log4j.core.LoggerContext;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.KEY_FILE_PATH;
-import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.TMP_DIR_PREFIX;
+import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.*;
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_BUNDLE;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ResourceConstants.NO_FILES_HISTORY;
@@ -87,6 +83,29 @@ public class ArchiveUtil {
                                      Paths.get(fxArchiveInfo.getArchivePath()).getFileName().toString());
         Files.copy(Path.of(fxArchiveInfo.getArchivePath()), backupArchive);
         return backupArchive;
+    }
+
+    public static boolean restoreBackupArchive(Path backupArchive, Path targetLocation) {
+        try {
+            if (Objects.nonNull(backupArchive) && Objects.nonNull(targetLocation) && Files.exists(backupArchive)) {
+                Files.copy(backupArchive, targetLocation, StandardCopyOption.REPLACE_EXISTING);
+                if (!backupArchive.toString().equals(targetLocation)) {
+                    Files.deleteIfExists(backupArchive);
+                }
+                return true;
+            }
+
+            return false;
+        } catch(Exception e) {
+            return false;
+        }
+    }
+
+    public static void removeBackupArchive(Path tempArchive) throws IOException {
+        Files.deleteIfExists(tempArchive);
+        if (tempArchive.getParent().getFileName().toString().matches(REGEX_TIMESTAMP_DIR) && Files.list(tempArchive.getParent()).count() == 0) {
+            Files.deleteIfExists(tempArchive.getParent());
+        }
     }
 
     public static List<FileInfo> handleDirectory(String prefix, Path root, Path directory, int depth, int index) throws IOException {

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/AbstractPearlZipTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/AbstractPearlZipTestFX.java
@@ -3,6 +3,7 @@
  */
 package com.ntak.pearlzip.ui.util;
 
+import com.ntak.pearlzip.archive.acc.pub.CommonsCompressArchiveReadService;
 import com.ntak.pearlzip.archive.acc.pub.CommonsCompressArchiveWriteService;
 import com.ntak.pearlzip.archive.szjb.pub.SevenZipArchiveService;
 import com.ntak.pearlzip.ui.constants.ZipConstants;
@@ -32,7 +33,7 @@ public abstract class AbstractPearlZipTestFX extends ApplicationTest {
         System.setProperty(CNS_NTAK_PEARL_ZIP_NO_FILES_HISTORY, "5");
         PearlZipFXUtil.initialise(stage,
                                   List.of(new CommonsCompressArchiveWriteService()),
-                                  List.of(new SevenZipArchiveService())
+                                  List.of(new SevenZipArchiveService(), new CommonsCompressArchiveReadService())
         );
         ZipConstants.LOCAL_TEMP = Paths.get(System.getProperty("user.home"), ".pz", "temp");
         ZipConstants.STORE_TEMP = Paths.get(System.getProperty("user.home"), ".pz", "temp");


### PR DESCRIPTION
+ Convenience methods created for handling backup archives
+ Copy, Move Migration and Delete - restore and remove back up as necessary
+ On Close handler - Temp parent compressor archive is unique to handle nested identical archives
+ File Zip Entry click handler - temp nested archive is stored in unique path to handle nested identical archive case
+ Options - Cache clear handles removal of timestamp directories
+ Set new archive service for tar in TestFX

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>