### PR TITLE
PZ-108,PZ-131 | Zip4J Archive Provider Implementation; Configurable Open archive dialog on an archive provider basis

### DIFF
--- a/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveReadService.java
+++ b/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveReadService.java
@@ -80,8 +80,7 @@ public class CommonsCompressArchiveReadService implements ArchiveReadService {
                         files.stream()
                              .filter(f -> Paths.get(f.getFileName()).getParent() != null)
                              .map(f-> Paths.get(f.getFileName()).getParent().toString())
-                             .filter(r-> !Strings.isEmpty(r))
-                             .filter(r->files.stream().map(FileInfo::getFileName).noneMatch(f->f.equals(r)))
+                             .filter(r-> !Strings.isEmpty(r) && files.stream().map(FileInfo::getFileName).noneMatch(f->f.equals(r)))
                              .distinct()
                              .collect(Collectors.toList());
 

--- a/pearl-zip-archive-zip4j/src/main/java/com/ntak/pearlzip/archive/zip4j/constants/Zip4jConstants.java
+++ b/pearl-zip-archive-zip4j/src/main/java/com/ntak/pearlzip/archive/zip4j/constants/Zip4jConstants.java
@@ -43,6 +43,9 @@ public class Zip4jConstants {
     public static final String LOG_ARCHIVE_Z4J_ISSUE_DELETING_FILE = "logging.ntak.pearl-zip.zip4j.issue-deleting-file";
     public static final String LOG_ARCHIVE_Z4J_ADDING_FILE = "logging.ntak.pearl-zip.zip4j.adding-file";
     public static final String LOG_ARCHIVE_Z4J_ISSUE_ADDING_FILE = "logging.ntak.pearl-zip.zip4j.issue-adding-file";
+    public static final String LOG_ARCHIVE_Z4J_ISSUE_EXTRACTING_FILE = "logging.ntak.pearl-zip.zip4j.issue-extracting-file";
     public static final String LOG_ARCHIVE_Z4J_ISSUE_GENERATING_METADATA =
             "logging.ntak.pearl-zip.zip4j.issue-generating-metadata";
+    public static final String LOG_ARCHIVE_Z4J_PASSWORD_SUCCESS = "logging.ntak.pearl-zip.zip4j.password-success";
+    public static final String LOG_ARCHIVE_Z4J_PASSWORD_FAIL = "logging.ntak.pearl-zip.zip4j.password-fail";
 }

--- a/pearl-zip-archive-zip4j/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/FrmZip4jPasswordController.java
+++ b/pearl-zip-archive-zip4j/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/FrmZip4jPasswordController.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021 92AK
+ */
+
+package com.ntak.pearlzip.archive.zip4j.pub;
+
+import com.ntak.pearlzip.archive.pub.ArchiveInfo;
+import com.ntak.pearlzip.archive.pub.FileInfo;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.PasswordField;
+import javafx.scene.layout.AnchorPane;
+import javafx.stage.WindowEvent;
+import javafx.util.Pair;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
+import static com.ntak.pearlzip.archive.zip4j.constants.Zip4jConstants.*;
+
+public class FrmZip4jPasswordController {
+
+    final AtomicBoolean isValid = new AtomicBoolean(false);
+    private final ArchiveInfo archiveInfo;
+    private final Zip4jArchiveReadService service;
+
+    @FXML
+    private AnchorPane panePassword;
+
+    @FXML
+    private PasswordField textPassword;
+
+    @FXML
+    private Button btnContinue;
+
+    public FrmZip4jPasswordController(Zip4jArchiveReadService service, ArchiveInfo archiveInfo) {
+        this.archiveInfo = archiveInfo;
+        this.service = service;
+    }
+
+    @FXML
+    public void initialize() {
+        textPassword.setOnKeyReleased((e)->{
+            archiveInfo.addProperty(KEY_ENCRYPTION_PW, textPassword.getText().toCharArray());
+        });
+
+        btnContinue.setOnAction(e->{
+            long sessionId = System.currentTimeMillis();
+            // Assumption: All files are encrypted uniformly in archive. So an arbitrary file can be taken to test
+            // password...
+            Optional<FileInfo> encFile = service.listFiles(sessionId, archiveInfo)
+                                              .stream()
+                                              .filter(f -> !f.isFolder())
+                                              .findFirst();
+            if (encFile.isPresent()) {
+                try {
+                    Path path = Files.createTempFile("tmp", "");
+                    isValid.set(service.extractFile(sessionId, path, archiveInfo, encFile.get()));
+                    Files.deleteIfExists(path);
+
+                    if (isValid.get()) {
+                        panePassword.setUserData(new Pair<>(isValid, resolveTextKey(LOG_ARCHIVE_Z4J_PASSWORD_SUCCESS)));
+                    } else {
+                        panePassword.setUserData(new Pair<>(isValid, resolveTextKey(LOG_ARCHIVE_Z4J_PASSWORD_FAIL)));
+                    }
+                } catch (IOException exc) {
+                    panePassword.setUserData(new Pair<>(isValid, resolveTextKey(LOG_ARCHIVE_Z4J_PASSWORD_FAIL)));
+                } finally {
+                    btnContinue.getScene().getWindow().fireEvent(new WindowEvent(btnContinue.getScene().getWindow(),
+                                                                                 WindowEvent.WINDOW_CLOSE_REQUEST));
+                }
+            }
+        });
+    }
+}

--- a/pearl-zip-archive-zip4j/src/main/resources/frmZip4jPassword.fxml
+++ b/pearl-zip-archive-zip4j/src/main/resources/frmZip4jPassword.fxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2021 92AK
+  -->
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.layout.AnchorPane?>
+
+<AnchorPane fx:id="panePassword" prefHeight="155.0" prefWidth="403.0" xmlns="http://javafx.com/javafx/15.0.1"
+            xmlns:fx="http://javafx.com/fxml/1">
+   <Label fx:id="lblPasswordDescription" alignment="TOP_LEFT" layoutX="14.0" layoutY="14.0" prefHeight="58.0"
+          prefWidth="378.0" text="%zip4j.password.description.text" wrapText="true"/>
+   <PasswordField fx:id="textPassword" layoutX="14.0" layoutY="80.0" prefHeight="27.0" prefWidth="378.0"/>
+   <Button fx:id="btnContinue" contentDisplay="RIGHT" layoutX="307.0" layoutY="114.0" mnemonicParsing="false"
+           prefHeight="27.0" prefWidth="85.0" text="%zip4j.password.continue" textAlignment="RIGHT"/>
+</AnchorPane>

--- a/pearl-zip-archive-zip4j/src/main/resources/zip4j_plugin_en_GB.properties
+++ b/pearl-zip-archive-zip4j/src/main/resources/zip4j_plugin_en_GB.properties
@@ -10,8 +10,13 @@ logging.ntak.pearl-zip.zip4j.adding-file=Adding file %s...
 logging.ntak.pearl-zip.zip4j.issue-adding-file=Issue adding to zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
 logging.ntak.pearl-zip.zip4j.deleting-file=Deleting file %s...
 logging.ntak.pearl-zip.zip4j.issue-deleting-file=Issue deleting from zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
+logging.ntak.pearl-zip.zip4j.issue-extracting-file=Issue extracting from zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
 logging.ntak.pearl-zip.zip4j.issue-creating-archive=Issue creating zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
 logging.ntak.pearl-zip.zip4j.issue-generating-metadata=Issue generating metadata for archive %s
+
+logging.ntak.pearl-zip.zip4j.password-success=Success
+logging.ntak.pearl-zip.zip4j.password-fail=Password invalid
+
 
 ###################################################################################################
 ######################################## NEW OPTIONS FORM LABELS ##################################
@@ -26,3 +31,10 @@ zip4j.new.options.encryption.password.text=Password:
 zip4j.new.options.encryption.algorithm.text=Encryption Algorithm: 
 zip4j.new.options.encryption.strength.text=Encryption Strength: 
 zip4j.new.options.description.text=The below options will help to configure Zip4j parameters when creating, augmenting or modifying the archive.
+
+###################################################################################################
+######################################## PASSWORD FORM LABELS ##################################
+###################################################################################################
+
+zip4j.password.description.text=The open archive is an encrypted Zip archive. \nPlease specify the password in order to decrypt and read the contents of files within the archive:
+zip4j.password.continue=Continue

--- a/pearl-zip-archive-zip4j/src/test/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadServiceTestCore.java
+++ b/pearl-zip-archive-zip4j/src/test/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadServiceTestCore.java
@@ -103,6 +103,24 @@ public abstract class Zip4jArchiveReadServiceTestCore {
     }
 
     @Test
+    @DisplayName("Test: List files from an encrypted archive with no password successfully")
+    public void testListFiles_EncryptedArchiveNoPassword_Success() {
+        List<String> expectations = Arrays.asList("level2","level2/level2-file","level2/UP-MOVE");
+        long sessionId = System.currentTimeMillis();
+        ArchiveInfo archiveInfo = new ArchiveInfo();
+        archiveInfo.setArchivePath(encryptedArchive.toAbsolutePath().toString());
+        archiveInfo.setArchiveFormat("zip");
+        archiveInfo.addProperty(KEY_ENCRYPTION_ENABLE, true);
+        archiveInfo.addProperty(KEY_ENCRYPTION_METHOD, AES);
+        archiveInfo.addProperty(KEY_ENCRYPTION_STRENGTH, KEY_STRENGTH_256);
+
+        List<FileInfo> files = service.listFiles(sessionId, archiveInfo);
+        Assertions.assertEquals(expectations.size(), files.size(), "The expected number of files was not read");
+        Assertions.assertTrue(files.stream().map(FileInfo::getFileName).allMatch(expectations::contains),
+                              "All filenames are accounted for in expectations");
+    }
+
+    @Test
     @DisplayName("Test: List files for an invalid archive will return an empty list")
     public void testListFiles_InvalidFile_Empty() {
         long sessionId = System.currentTimeMillis();

--- a/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
+++ b/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
@@ -199,6 +199,11 @@ title.ntak.pearl-zip.archive-does-not-exist=ERROR: Archive not present
 header.ntak.pearl-zip.archive-does-not-exist=Cannot process archive
 body.ntak.pearl-zip.archive-does-not-exist=Archive %s does not exist. PearlZip will now close the instance.
 
+logging.ntak.pearl-zip.invalid-archive-setup=Issue occurred when opening archive %s. Issue reason: %s
+title.ntak.pearl-zip.invalid-archive-setup=Invalid Archive Setup
+header.ntak.pearl-zip.invalid-archive-setup=Archive could not be open
+body.ntak.pearl-zip.invalid-archive-setup=There were issues opening the archive. Reason given by plugin for issue: %s. Check logs for further details.
+
 ###################################################################################################
 ######################################## LABEL TEXT KEYS ##########################################
 ###################################################################################################

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -207,6 +207,11 @@ public class ZipConstants {
     public static final String HEADER_CLEAR_CACHE = "header.ntak.pearl-zip.clear-cache";
     public static final String BODY_CLEAR_CACHE = "body.ntak.pearl-zip.clear-cache";
 
+    public static final String LOG_INVALID_ARCHIVE_SETUP = "logging.ntak.pearl-zip.invalid-archive-setup";
+    public static final String TITLE_INVALID_ARCHIVE_SETUP = "title.ntak.pearl-zip.invalid-archive-setup";
+    public static final String HEADER_INVALID_ARCHIVE_SETUP = "header.ntak.pearl-zip.invalid-archive-setup";
+    public static final String BODY_INVALID_ARCHIVE_SETUP = "body.ntak.pearl-zip.invalid-archive-setup";
+
     public static final String LOG_ISSUE_SAVE_ARCHIVE = "logging.ntak.pearl-zip.issue-save-archive";
 
     public static final String TITLE_PATTERN = "title.ntak.pearl-zip.title-pattern";

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnOpenEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnOpenEventHandler.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
@@ -74,12 +75,12 @@ public class BtnOpenEventHandler implements EventHandler<MouseEvent> {
                                                    // Open in Current Window
                                                    new ButtonType(resolveTextKey(BTN_OPEN_NEW_WINDOW_NO), ButtonBar.ButtonData.NO));
         long sessionId = System.currentTimeMillis();
-        final Stage newStage = new Stage();
-        executeBackgroundProcess(sessionId, newStage,
-                                 ()->ArchiveUtil.openFile(rawFile),
-                                 (s)-> {
+        AtomicBoolean openSuccess = new AtomicBoolean(false);
+        executeBackgroundProcess(sessionId, stage,
+                                 () -> openSuccess.set(ArchiveUtil.openFile(rawFile, stage)),
+                                 (s) -> {
                                              // Default new window
-                                             if (response.isPresent() && response.get()
+                                             if (openSuccess.get() && response.isPresent() && response.get()
                                                                                  .getButtonData()
                                                                                  .equals(ButtonBar.ButtonData.NO)) {
                                                  Platform.runLater(() -> this.stage.fireEvent(new WindowEvent(this.stage,


### PR DESCRIPTION


PZ-131:
+ Zip4j implemented pre-open password dialog on opening an encrypted zip archive
+ Updated BtnOpenEventHandler, ArchiveUtil to factor in the optional pre-open dialog
+ Added logging keys and en-GB log patterns
+ Added test case showing encrypted archive metadata is still readable

PZ-108:

Other:
+ Optimised Apache Commons implementation stream

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>