### PR TITLE
PZ-100 | Open archive in PearlZip through macOs Finder Application

### DIFF
--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -3,7 +3,7 @@
  */
 package com.ntak.pearlzip.ui.constants;
 
-import com.ntak.pearlzip.ui.pub.ZipLauncher;
+import com.ntak.pearlzip.ui.pub.MacZipLauncher;
 import com.ntak.pearlzip.ui.util.ErrorAlertConsumer;
 import com.ntak.pearlzip.ui.util.ProgressMessageTraceLogger;
 import de.jangassen.MenuToolkit;
@@ -241,7 +241,7 @@ public class ZipConstants {
     public static final String LBL_CLEAR_UP_RECENTS = "label.ntak.pearl-zip.clear-up-recents";
     public static final FileSystem JRT_FILE_SYSTEM = FileSystems.getFileSystem(URI.create("jrt:/"));
 
-    public static ZipLauncher APP;
+    public static MacZipLauncher APP;
     public static Path LOCAL_TEMP;
     public static Path STORE_ROOT;
     public static Path STORE_TEMP;

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/MacZipLauncher.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/MacZipLauncher.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2021 92AK
+ */
+package com.ntak.pearlzip.ui.pub;
+
+import com.ntak.pearlzip.archive.constants.LoggingConstants;
+import com.ntak.pearlzip.archive.pub.ArchiveReadService;
+import com.ntak.pearlzip.archive.pub.ArchiveService;
+import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
+import com.ntak.pearlzip.archive.util.LoggingUtil;
+import com.ntak.pearlzip.ui.constants.ZipConstants;
+import com.ntak.pearlzip.ui.model.FXArchiveInfo;
+import com.ntak.pearlzip.ui.model.ZipState;
+import com.ntak.pearlzip.ui.util.ErrorAlertConsumer;
+import com.ntak.pearlzip.ui.util.JFXUtil;
+import com.ntak.pearlzip.ui.util.ProgressMessageTraceLogger;
+import de.jangassen.model.AppearanceMode;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuBar;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+import javafx.util.Pair;
+
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.ntak.pearlzip.archive.constants.ArchiveConstants.COM_BUS_EXECUTOR_SERVICE;
+import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_BUNDLE;
+import static com.ntak.pearlzip.archive.constants.LoggingConstants.ROOT_LOGGER;
+import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
+import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
+import static com.ntak.pearlzip.ui.pub.ZipLauncher.OS_FILES;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.addToRecentFile;
+import static com.ntak.pearlzip.ui.util.ArchiveUtil.launchMainStage;
+
+/**
+ *  Loads the main UI screen for the Zip Application.
+ *  @author Aashutos Kakshepati
+*/
+public class MacZipLauncher extends Application {
+
+    static {
+            Desktop.getDesktop().setOpenFileHandler((e)-> e.getFiles()
+                                                       .stream()
+                                                       .peek(LoggingConstants.ROOT_LOGGER::info)
+                                                       .map(f -> f.toPath()
+                        .toAbsolutePath()
+                        .toString())
+                                                       .forEach(f -> Platform.runLater(()-> {
+                                                       Stage stage = new Stage();
+                                                       ArchiveReadService readService = ZipState.getReadArchiveServiceForFile(f).get();
+                                                       ArchiveWriteService writeService = ZipState.getWriteArchiveServiceForFile(f).orElse(null);
+                                                       final FXArchiveInfo fxArchiveInfo = new FXArchiveInfo(f, readService, writeService);
+                                                       launchMainStage(stage, fxArchiveInfo);
+                                                      })));
+    }
+
+    @Override
+    public void start(Stage stage) throws IOException, InterruptedException {
+        APP = this;
+
+        CountDownLatch readyLatch = new CountDownLatch(1);
+
+        // Loading additional EventBus consumers
+        MESSAGE_TRACE_LOGGER = ProgressMessageTraceLogger.getMessageTraceLogger();
+        ArchiveService.DEFAULT_BUS.register(MESSAGE_TRACE_LOGGER);
+
+        ERROR_ALERT_CONSUMER = ErrorAlertConsumer.getErrorAlertConsumer();
+        ArchiveService.DEFAULT_BUS.register(ERROR_ALERT_CONSUMER);
+
+        ////////////////////////////////////////////
+        ///// Create files and dir structure //////
+        //////////////////////////////////////////
+
+        // Create temporary store folder
+        ZipConstants.STORE_TEMP = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "temp");
+        if (!Files.exists(STORE_TEMP)) {
+            Files.createDirectories(STORE_TEMP);
+        }
+
+        // Providers
+        Path providerPath = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "providers");
+        Files.createDirectories(providerPath);
+
+        // Recent files
+        RECENT_FILE = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "rf");
+        if (!Files.exists(RECENT_FILE)) {
+            Files.createFile(RECENT_FILE);
+        }
+
+        ////////////////////////////////////////////
+        ///// Create System Menu //////////////////
+        //////////////////////////////////////////
+
+        // Create a new System Menu
+        String appName = System.getProperty(CNS_NTAK_PEARL_ZIP_APP_NAME, "PearlZip");
+        MenuBar sysMenu = new MenuBar();
+
+        // Setting about form...
+        FXMLLoader aboutLoader = new FXMLLoader();
+        aboutLoader.setLocation(MacZipLauncher.class.getClassLoader().getResource("frmAbout.fxml"));
+        aboutLoader.setResources(LOG_BUNDLE);
+        VBox abtRoot = aboutLoader.load();
+        FrmAboutController abtController = aboutLoader.getController();
+        Scene abtScene = new Scene(abtRoot);
+        Stage aboutStage = new Stage();
+        abtController.initData(aboutStage);
+        aboutStage.setScene(abtScene);
+        aboutStage.initStyle(StageStyle.UNDECORATED);
+
+        sysMenu.setUseSystemMenuBar(true);
+        sysMenu.getMenus().add(MENU_TOOLKIT.createDefaultApplicationMenu(appName, aboutStage));
+
+        // Add some more Menus...
+        FXMLLoader menuLoader = new FXMLLoader();
+        menuLoader.setLocation(MacZipLauncher.class.getClassLoader().getResource("sysmenu.fxml"));
+        menuLoader.setResources(LOG_BUNDLE);
+        MenuBar additionalMenu = menuLoader.load();
+        SysMenuController menuController = menuLoader.getController();
+        menuController.initData();
+        sysMenu.getMenus().addAll(additionalMenu.getMenus());
+
+        // Use the menu sysMenu for all stages including new ones
+        MENU_TOOLKIT.setAppearanceMode(AppearanceMode.DARK);
+        MENU_TOOLKIT.setMenuBar(sysMenu);
+
+        // Initialise archive information
+        readyLatch.countDown();
+        FXArchiveInfo fxArchiveInfo;
+        String archivePath;
+        if (APP.getParameters().getRaw().size() > 0 && Files.exists(Paths.get(APP.getParameters()
+                                                                                 .getRaw()
+                                                                                 .get(0)))) {
+            archivePath = APP.getParameters()
+                                    .getRaw()
+                                    .get(0);
+            addToRecentFile(new File(archivePath));
+        } else if (OS_FILES.size() > 0) {
+            // LOG: OS Trigger detected...
+            LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_OS_TRIGGER_DETECTED));
+
+            while (OS_FILES.size() < 1) {
+                Thread.sleep(250);
+            }
+
+            archivePath = OS_FILES.remove(0);
+        } else {
+            archivePath = Paths.get(STORE_TEMP.toString(),
+                                    String.format("a%s.zip", System.currentTimeMillis())).toAbsolutePath().toString();
+            ZipState.getWriteArchiveServiceForFile(archivePath).get().createArchive(System.currentTimeMillis(), archivePath);
+        }
+
+        ArchiveReadService readService = ZipState.getReadArchiveServiceForFile(archivePath).get();
+        ArchiveWriteService writeService = ZipState.getWriteArchiveServiceForFile(archivePath).orElse(null);
+                fxArchiveInfo = new FXArchiveInfo(archivePath,
+                                                  readService, writeService);
+
+        // Generates PreOpen dialog, if required
+        Optional<Node> optNode;
+        if ((optNode = readService.getOpenArchiveOptionsPane(fxArchiveInfo.getArchiveInfo())).isPresent()) {
+            stage.initStyle(StageStyle.TRANSPARENT);
+            stage.show();
+
+            Stage preOpenStage = new Stage();
+            Node root = optNode.get();
+            JFXUtil.loadPreOpenDialog(preOpenStage, root);
+
+            Pair<AtomicBoolean,String> result = (Pair<AtomicBoolean, String>) root.getUserData();
+
+            if (Objects.nonNull(result) && Objects.nonNull(result.getKey()) && !result.getKey().get()) {
+                // LOG: Issue occurred when opening archive %s. Issue reason: %s
+                ROOT_LOGGER.error(resolveTextKey(LOG_INVALID_ARCHIVE_SETUP, fxArchiveInfo.getArchivePath(),
+                                                 result.getValue()));
+
+                Platform.runLater(()-> stage.fireEvent(new WindowEvent(stage, WindowEvent.WINDOW_CLOSE_REQUEST)));
+                return;
+            }
+
+            Platform.runLater(()-> {
+                launchMainStage(new Stage(), fxArchiveInfo);
+                stage.fireEvent(new WindowEvent(stage, WindowEvent.WINDOW_CLOSE_REQUEST));
+            });
+        } else {
+            launchMainStage(stage, fxArchiveInfo);
+        }
+    }
+
+    @Override
+    public void stop() {
+        COM_BUS_EXECUTOR_SERVICE.shutdown();
+        PRIMARY_EXECUTOR_SERVICE.shutdown();
+    }
+
+    public static void main(String[] args) {
+        try {
+            ZipLauncher.initialize();
+            LoggingConstants.ROOT_LOGGER.debug(Arrays.toString(args));
+            launch(args);
+        } catch(Exception e) {
+            LoggingConstants.ROOT_LOGGER.error(e.getMessage());
+            LoggingConstants.ROOT_LOGGER.error(LoggingUtil.getStackTraceFromException(e));
+        }
+    }
+
+}

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
@@ -5,25 +5,15 @@ package com.ntak.pearlzip.ui.pub;
 
 import com.ntak.pearlzip.archive.constants.ConfigurationConstants;
 import com.ntak.pearlzip.archive.constants.LoggingConstants;
-import com.ntak.pearlzip.archive.pub.ArchiveReadService;
-import com.ntak.pearlzip.archive.pub.ArchiveService;
-import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
-import com.ntak.pearlzip.archive.util.LoggingUtil;
 import com.ntak.pearlzip.license.pub.LicenseService;
 import com.ntak.pearlzip.license.pub.PearlZipLicenseService;
 import com.ntak.pearlzip.ui.constants.ZipConstants;
-import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import com.ntak.pearlzip.ui.model.ZipState;
-import com.ntak.pearlzip.ui.util.*;
+import com.ntak.pearlzip.ui.util.MetricProfile;
+import com.ntak.pearlzip.ui.util.MetricProfileFactory;
+import com.ntak.pearlzip.ui.util.MetricThreadFactory;
+import com.ntak.pearlzip.ui.util.ModuleUtil;
 import de.jangassen.MenuToolkit;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.fxml.FXMLLoader;
-import javafx.scene.Scene;
-import javafx.scene.control.MenuBar;
-import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Configurator;
 
@@ -31,313 +21,190 @@ import java.awt.*;
 import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 
-import static com.ntak.pearlzip.archive.constants.ArchiveConstants.*;
+import static com.ntak.pearlzip.archive.constants.ArchiveConstants.CURRENT_SETTINGS;
+import static com.ntak.pearlzip.archive.constants.ArchiveConstants.WORKING_SETTINGS;
 import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.CNS_RES_BUNDLE;
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_BUNDLE;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.genLocale;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
-import static com.ntak.pearlzip.ui.util.ArchiveUtil.addToRecentFile;
-import static com.ntak.pearlzip.ui.util.ArchiveUtil.launchMainStage;
 
 /**
  *  Loads the main UI screen for the Zip Application.
  *  @author Aashutos Kakshepati
 */
-public class ZipLauncher extends Application {
+public class ZipLauncher {
 
-    private static MenuToolkit MENU_TOOLKIT;
+    public static final CopyOnWriteArrayList<String> OS_FILES = new CopyOnWriteArrayList<>();
 
+    // Reference: https://github.com/eschmar/javafx-custom-file-ext-boilerplate
     static {
         if (Desktop.getDesktop().isSupported(Desktop.Action.APP_OPEN_FILE)) {
-            Desktop.getDesktop().setOpenFileHandler((e)->{
-                e.getFiles()
-                 .stream()
-                 .peek(LoggingConstants.ROOT_LOGGER::info)
-                 .map(f -> f.toPath()
-                            .toAbsolutePath()
-                            .toString())
-                 .forEach(f -> {
-                     Stage stage = new Stage();
-                     ArchiveReadService readService = ZipState.getReadArchiveServiceForFile(f).get();
-                     ArchiveWriteService writeService = ZipState.getWriteArchiveServiceForFile(f).orElse(null);
-                     final FXArchiveInfo fxArchiveInfo = new FXArchiveInfo(f, readService, writeService);
-                     Platform.runLater(()->launchMainStage(stage, fxArchiveInfo));
-                 });
-                e.getFiles()
-                 .stream()
-                 .map(f -> f.toPath()
-                            .toAbsolutePath()
-                            .toString())
-                 .forEach(l -> {
-                     try {
-                         Files.writeString(Paths.get("~", "tmp"), l, StandardOpenOption.APPEND);
-                     } catch(IOException ioException) {
-                     }
-                 });
-            });
+            Desktop.getDesktop().setOpenFileHandler((e)-> e.getFiles().stream().map(File::getAbsolutePath).forEach(l -> {
+                try {
+                    OS_FILES.add(l);
+                } catch(Exception exc) {
+                }
+            }));
         }
-    }
-
-    @Override
-    public void start(Stage stage) throws IOException {
-        APP = this;
-
-        CountDownLatch readyLatch = new CountDownLatch(1);
-
-        // Loading additional EventBus consumers
-        MESSAGE_TRACE_LOGGER = ProgressMessageTraceLogger.getMessageTraceLogger();
-        ArchiveService.DEFAULT_BUS.register(MESSAGE_TRACE_LOGGER);
-
-        ERROR_ALERT_CONSUMER = ErrorAlertConsumer.getErrorAlertConsumer();
-        ArchiveService.DEFAULT_BUS.register(ERROR_ALERT_CONSUMER);
-
-        ////////////////////////////////////////////
-        ///// Create files and dir structure //////
-        //////////////////////////////////////////
-
-        // Create temporary store folder
-        ZipConstants.STORE_TEMP = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "temp");
-        if (!Files.exists(STORE_TEMP)) {
-            Files.createDirectories(STORE_TEMP);
-        }
-
-        // Providers
-        Path providerPath = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "providers");
-        Files.createDirectories(providerPath);
-
-        // Recent files
-        RECENT_FILE = Paths.get(STORE_ROOT.toAbsolutePath().toString(), "rf");
-        if (!Files.exists(RECENT_FILE)) {
-            Files.createFile(RECENT_FILE);
-        }
-
-        ////////////////////////////////////////////
-        ///// Create System Menu //////////////////
-        //////////////////////////////////////////
-
-        // Create a new System Menu
-        String appName = System.getProperty(CNS_NTAK_PEARL_ZIP_APP_NAME, "PearlZip");
-        MenuBar sysMenu = new MenuBar();
-
-        // Setting about form...
-        FXMLLoader aboutLoader = new FXMLLoader();
-        aboutLoader.setLocation(ZipLauncher.class.getClassLoader().getResource("frmAbout.fxml"));
-        aboutLoader.setResources(LOG_BUNDLE);
-        VBox abtRoot = aboutLoader.load();
-        FrmAboutController abtController = aboutLoader.getController();
-        Scene abtScene = new Scene(abtRoot);
-        Stage aboutStage = new Stage();
-        abtController.initData(aboutStage);
-        aboutStage.setScene(abtScene);
-        aboutStage.initStyle(StageStyle.UNDECORATED);
-
-        sysMenu.setUseSystemMenuBar(true);
-        sysMenu.getMenus().add(MENU_TOOLKIT.createDefaultApplicationMenu(appName, aboutStage));
-
-        // Add some more Menus...
-        FXMLLoader menuLoader = new FXMLLoader();
-        menuLoader.setLocation(ZipLauncher.class.getClassLoader().getResource("sysmenu.fxml"));
-        menuLoader.setResources(LOG_BUNDLE);
-        MenuBar additionalMenu = menuLoader.load();
-        SysMenuController menuController = menuLoader.getController();
-        menuController.initData();
-        sysMenu.getMenus().addAll(additionalMenu.getMenus());
-
-        // Use the menu sysMenu for all stages including new ones
-        MENU_TOOLKIT.setGlobalMenuBar(sysMenu);
-
-        // Initialise archive information
-        readyLatch.countDown();
-        FXArchiveInfo fxArchiveInfo;
-        String archivePath;
-        if (APP.getParameters().getRaw().size() > 0 && Files.exists(Paths.get(APP.getParameters()
-                                                                                 .getRaw()
-                                                                                 .get(0)))) {
-            archivePath = APP.getParameters()
-                                    .getRaw()
-                                    .get(0);
-            addToRecentFile(new File(archivePath));
-        } else if (APP.getParameters().getRaw().size() > 0 && APP.getParameters().getRaw().get(0).startsWith("-psn_")) {
-            // LOG: OS Trigger detected...
-            LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_OS_TRIGGER_DETECTED));
-            return;
-        } else {
-            archivePath = Paths.get(STORE_TEMP.toString(),
-                                    String.format("a%s.zip", System.currentTimeMillis())).toAbsolutePath().toString();
-            ZipState.getWriteArchiveServiceForFile(archivePath).get().createArchive(System.currentTimeMillis(), archivePath);
-        }
-
-        ArchiveReadService readService = ZipState.getReadArchiveServiceForFile(archivePath).get();
-        ArchiveWriteService writeService = ZipState.getWriteArchiveServiceForFile(archivePath).orElse(null);
-                fxArchiveInfo = new FXArchiveInfo(archivePath,
-                                                  readService, writeService);
-        launchMainStage(stage, fxArchiveInfo);
-    }
-
-    @Override
-    public void stop() {
-        COM_BUS_EXECUTOR_SERVICE.shutdown();
-        PRIMARY_EXECUTOR_SERVICE.shutdown();
     }
 
     public static void main(String[] args) {
-        try {
-            LoggingConstants.ROOT_LOGGER.debug(Arrays.toString(args));
+       MacZipLauncher.main(args);
 
-            // Load bootstrap properties
-            Properties props = new Properties();
-            props.load(ZipLauncher.class.getClassLoader()
-                                        .getResourceAsStream("application.properties"));
-            ZipConstants.STORE_ROOT = Paths.get(System.getProperty(CNS_STORE_ROOT, String.format("%s/.pz",
-                                                                                                 System.getProperty(
-                                                                                                         "user.home"))));
-            ZipConstants.LOCAL_TEMP =
-                    Paths.get(Optional.ofNullable(System.getenv("TMPDIR"))
-                                      .orElse(STORE_ROOT.toString()));
-            Path externalBootstrapFile = Paths.get(STORE_ROOT.toString(), "application.properties");
-
-            String defaultModulePath = Path.of(STORE_ROOT.toAbsolutePath().toString(), "providers").toString();
-            ZipConstants.RUNTIME_MODULE_PATH =
-                    Paths.get(System.getProperty(CNS_NTAK_PEARL_ZIP_MODULE_PATH, defaultModulePath)).toAbsolutePath();
-
-            ////////////////////////////////////////////
-            ///// Settings File Load ///////////////////
-            ////////////////////////////////////////////
-
-            SETTINGS_FILE = Paths.get(System.getProperty(CNS_SETTINGS_FILE, Paths.get(STORE_ROOT.toString(),
-                                                         "settings.properties").toString()));
-            if (!Files.exists(SETTINGS_FILE)) {
-                Files.createFile(SETTINGS_FILE);
-            }
-            try(InputStream settingsIStream = Files.newInputStream(SETTINGS_FILE)) {
-                CURRENT_SETTINGS.load(settingsIStream);
-                WORKING_SETTINGS.load(settingsIStream);
-            }
-
-            // Overwrite with external properties file
-            // Reserved properties are kept as per internal key definition
-            Map<String,String> reservedKeyMap = new HashMap<>();
-            Path tmpRK = Paths.get(STORE_ROOT.toString(), "rk");
-            try (FileOutputStream fileOutputStream = new FileOutputStream(tmpRK.toString());
-                    FileChannel channel = fileOutputStream.getChannel();
-                    FileLock lock = channel.lock()) {
-                    // Standard resource case
-                    Path reservedKeys = Paths.get(ZipLauncher.class.getClassLoader()
-                                                               .getResource("reserved-keys")
-                                                               .getPath());
-                    LoggingConstants.ROOT_LOGGER.info(reservedKeys);
-
-                    // standard/jar resource case
-                    if (Objects.nonNull(reservedKeys)) {
-
-                        try (InputStream is = ZipLauncher.class.getClassLoader()
-                                                               .getResourceAsStream("reserved-keys")) {
-                            Files.copy(is, tmpRK, StandardCopyOption.REPLACE_EXISTING);
-                        }
-                    } else if (!Files.exists(reservedKeys)) {
-                        reservedKeys = JRT_FILE_SYSTEM.getPath("modules", "com.ntak.pearlzip.ui", "reserved-keys");
-                        Files.copy(reservedKeys, tmpRK, StandardCopyOption.REPLACE_EXISTING);
-                    }
-
-                    Files.lines(tmpRK)
-                     .filter(k -> Objects.nonNull(k) && Objects.nonNull(props.getProperty(k)))
-                     // LOG: Locking in key: %s with value: %s
-                     .peek(k -> LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOCKING_IN_PROPERTY, k, props.getProperty(k))))
-                     .forEach(k -> reservedKeyMap.put(k, props.getProperty(k)));
-            }
-
-            if (Files.exists(externalBootstrapFile)) {
-                props.load(Files.newBufferedReader(externalBootstrapFile));
-            }
-
-            props.putAll(System.getProperties());
-            props.putAll(reservedKeyMap);
-            System.setProperties(props);
-            LoggingConstants.ROOT_LOGGER.info(props);
-
-            ////////////////////////////////////////////
-            ///// Log4j Setup /////////////////////////
-            //////////////////////////////////////////
-
-            // Create root store
-            Files.createDirectories(ZipConstants.STORE_ROOT);
-
-            // Log4j configuration - handle fixed parameters when creating application image
-            String log4jCfg = Paths.get(STORE_ROOT.toString(), "log4j2.xml")
-                                   .toString();
-            final Path log4jPath = Paths.get(log4jCfg);
-            if (!Files.exists(log4jPath)) {
-                Path logCfgFile = JRT_FILE_SYSTEM.getPath("modules", "com.ntak.pearlzip.archive", "log4j2.xml");
-                try(InputStream is = Files.newInputStream(logCfgFile)) {
-                    Files.copy(is, log4jPath);
-                } catch(Exception e) {
-
-                }
-            }
-            ConfigurationSource source = new ConfigurationSource(new FileInputStream(log4jCfg));
-            Configurator.initialize(null, source);
-
-            // Setting Locale
-            Locale.setDefault(genLocale(props));
-            ResourceBundle.getBundle(System.getProperty(ConfigurationConstants.CNS_CUSTOM_RES_BUNDLE, "custom"),
-                                     Locale.getDefault());
-            LOG_BUNDLE = ResourceBundle.getBundle(System.getProperty(CNS_RES_BUNDLE, "pearlzip"),
-                                                  Locale.getDefault());
-            MENU_TOOLKIT = MenuToolkit.toolkit(Locale.getDefault());
-
-            // Load License Declarations
-            LicenseService licenseService = new PearlZipLicenseService();
-            licenseService.retrieveDeclaredLicenses()
-                          .forEach(ZipState::addLicenseDeclaration);
-
-            ////////////////////////////////////////////
-            ///// Runtime Module Load /////////////////
-            //////////////////////////////////////////
-
-            if (Files.isDirectory(RUNTIME_MODULE_PATH)) {
-                // LOG: Loading modules from path: %s
-                LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOADING_MODULE, RUNTIME_MODULE_PATH.toAbsolutePath().toString()));
-                ModuleUtil.loadModulesDynamic(RUNTIME_MODULE_PATH);
-            } else {
-                ModuleUtil.loadModulesStatic();
-            }
-
-            // Initialising Thread Pool
-            String klassName;
-            MetricProfile profile = MetricProfile.getDefaultProfile();
-            if (Objects.nonNull(klassName = System.getProperty(CNS_METRIC_FACTORY))) {
-                try {
-                    MetricProfileFactory factory = (MetricProfileFactory) Class.forName(klassName)
-                                                                               .getDeclaredConstructor()
-                                                                               .newInstance();
-                    profile = factory.getProfile();
-                } catch(Exception e) {
-
-                }
-                PRIMARY_EXECUTOR_SERVICE =
-                        Executors.newScheduledThreadPool(Math.max(Integer.parseInt(System.getProperty(
-                                CNS_THREAD_POOL_SIZE,
-                                "4")), 1),
-                                                         MetricThreadFactory.create(profile));
-            } else {
-                PRIMARY_EXECUTOR_SERVICE =
-                        Executors.newScheduledThreadPool(Math.max(Integer.parseInt(System.getProperty(
-                                CNS_THREAD_POOL_SIZE,
-                                "4")), 1),
-                                                         MetricThreadFactory.create(MetricProfile.getDefaultProfile()));
-            }
-
-            launch(args);
-        } catch(Exception e) {
-            LoggingConstants.ROOT_LOGGER.error(e.getMessage());
-            LoggingConstants.ROOT_LOGGER.error(LoggingUtil.getStackTraceFromException(e));
-        }
+       Runtime.getRuntime().exit(0);
     }
 
+    public static void initialize() throws IOException {
+        // Load bootstrap properties
+        Properties props = new Properties();
+        props.load(MacZipLauncher.class.getClassLoader()
+                                       .getResourceAsStream("application.properties"));
+        ZipConstants.STORE_ROOT = Paths.get(System.getProperty(CNS_STORE_ROOT, String.format("%s/.pz",
+                                                                                             System.getProperty(
+                                                                                                     "user.home"))));
+        ZipConstants.LOCAL_TEMP =
+                Paths.get(Optional.ofNullable(System.getenv("TMPDIR"))
+                                  .orElse(STORE_ROOT.toString()));
+        Path externalBootstrapFile = Paths.get(STORE_ROOT.toString(), "application.properties");
+
+        String defaultModulePath = Path.of(STORE_ROOT.toAbsolutePath().toString(), "providers").toString();
+        ZipConstants.RUNTIME_MODULE_PATH =
+                Paths.get(System.getProperty(CNS_NTAK_PEARL_ZIP_MODULE_PATH, defaultModulePath)).toAbsolutePath();
+
+        ////////////////////////////////////////////
+        ///// Settings File Load ///////////////////
+        ////////////////////////////////////////////
+
+        SETTINGS_FILE = Paths.get(System.getProperty(CNS_SETTINGS_FILE, Paths.get(STORE_ROOT.toString(),
+                                                     "settings.properties").toString()));
+        if (!Files.exists(SETTINGS_FILE)) {
+            Files.createFile(SETTINGS_FILE);
+        }
+        try(InputStream settingsIStream = Files.newInputStream(SETTINGS_FILE)) {
+            CURRENT_SETTINGS.load(settingsIStream);
+            WORKING_SETTINGS.load(settingsIStream);
+        }
+
+        // Overwrite with external properties file
+        // Reserved properties are kept as per internal key definition
+        Map<String,String> reservedKeyMap = new HashMap<>();
+        Path tmpRK = Paths.get(STORE_ROOT.toString(), "rk");
+        try (FileOutputStream fileOutputStream = new FileOutputStream(tmpRK.toString());
+             FileChannel channel = fileOutputStream.getChannel();
+             FileLock lock = channel.lock()) {
+                // Standard resource case
+                Path reservedKeys = Paths.get(MacZipLauncher.class.getClassLoader()
+                                                                  .getResource("reserved-keys")
+                                                                  .getPath());
+                LoggingConstants.ROOT_LOGGER.info(reservedKeys);
+
+                // standard/jar resource case
+                if (Objects.nonNull(reservedKeys)) {
+
+                    try (InputStream is = MacZipLauncher.class.getClassLoader()
+                                                              .getResourceAsStream("reserved-keys")) {
+                        Files.copy(is, tmpRK, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } else if (!Files.exists(reservedKeys)) {
+                    reservedKeys = JRT_FILE_SYSTEM.getPath("modules", "com.ntak.pearlzip.ui", "reserved-keys");
+                    Files.copy(reservedKeys, tmpRK, StandardCopyOption.REPLACE_EXISTING);
+                }
+
+                Files.lines(tmpRK)
+                 .filter(k -> Objects.nonNull(k) && Objects.nonNull(props.getProperty(k)))
+                 // LOG: Locking in key: %s with value: %s
+                 .peek(k -> LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOCKING_IN_PROPERTY, k, props.getProperty(k))))
+                 .forEach(k -> reservedKeyMap.put(k, props.getProperty(k)));
+        }
+
+        if (Files.exists(externalBootstrapFile)) {
+            props.load(Files.newBufferedReader(externalBootstrapFile));
+        }
+
+        props.putAll(System.getProperties());
+        props.putAll(reservedKeyMap);
+        System.setProperties(props);
+        LoggingConstants.ROOT_LOGGER.info(props);
+
+        ////////////////////////////////////////////
+        ///// Log4j Setup /////////////////////////
+        //////////////////////////////////////////
+
+        // Create root store
+        Files.createDirectories(ZipConstants.STORE_ROOT);
+
+        // Log4j configuration - handle fixed parameters when creating application image
+        String log4jCfg = Paths.get(STORE_ROOT.toString(), "log4j2.xml")
+                               .toString();
+        final Path log4jPath = Paths.get(log4jCfg);
+        if (!Files.exists(log4jPath)) {
+            Path logCfgFile = JRT_FILE_SYSTEM.getPath("modules", "com.ntak.pearlzip.archive", "log4j2.xml");
+            try(InputStream is = Files.newInputStream(logCfgFile)) {
+                Files.copy(is, log4jPath);
+            } catch(Exception e) {
+
+            }
+        }
+        ConfigurationSource source = new ConfigurationSource(new FileInputStream(log4jCfg));
+        Configurator.initialize(null, source);
+
+        // Setting Locale
+        Locale.setDefault(genLocale(props));
+        ResourceBundle.getBundle(System.getProperty(ConfigurationConstants.CNS_CUSTOM_RES_BUNDLE, "custom"),
+                                 Locale.getDefault());
+        LOG_BUNDLE = ResourceBundle.getBundle(System.getProperty(CNS_RES_BUNDLE, "pearlzip"),
+                                              Locale.getDefault());
+        ZipConstants.MENU_TOOLKIT = MenuToolkit.toolkit(Locale.getDefault());
+
+        // Load License Declarations
+        LicenseService licenseService = new PearlZipLicenseService();
+        licenseService.retrieveDeclaredLicenses()
+                      .forEach(ZipState::addLicenseDeclaration);
+
+        ////////////////////////////////////////////
+        ///// Runtime Module Load /////////////////
+        //////////////////////////////////////////
+
+        if (Files.isDirectory(RUNTIME_MODULE_PATH)) {
+            // LOG: Loading modules from path: %s
+            LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOADING_MODULE, RUNTIME_MODULE_PATH.toAbsolutePath().toString()));
+            ModuleUtil.loadModulesDynamic(RUNTIME_MODULE_PATH);
+        } else {
+            ModuleUtil.loadModulesStatic();
+        }
+
+        // Initialising Thread Pool
+        String klassName;
+        MetricProfile profile = MetricProfile.getDefaultProfile();
+        if (Objects.nonNull(klassName = System.getProperty(CNS_METRIC_FACTORY))) {
+            try {
+                MetricProfileFactory factory = (MetricProfileFactory) Class.forName(klassName)
+                                                                           .getDeclaredConstructor()
+                                                                           .newInstance();
+                profile = factory.getProfile();
+            } catch(Exception e) {
+
+            }
+            PRIMARY_EXECUTOR_SERVICE =
+                    Executors.newScheduledThreadPool(Math.max(Integer.parseInt(System.getProperty(
+                            CNS_THREAD_POOL_SIZE,
+                            "4")), 1),
+                                                     MetricThreadFactory.create(profile));
+        } else {
+            PRIMARY_EXECUTOR_SERVICE =
+                    Executors.newScheduledThreadPool(Math.max(Integer.parseInt(System.getProperty(
+                            CNS_THREAD_POOL_SIZE,
+                            "4")), 1),
+                                                     MetricThreadFactory.create(MetricProfile.getDefaultProfile()));
+        }
+    }
 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
@@ -287,14 +287,7 @@ public class ArchiveUtil {
                 CountDownLatch latch = new CountDownLatch(1);
                 Platform.runLater(()->{
                     Stage preOpenStage = new Stage();
-                    AnchorPane pane = new AnchorPane(root);
-                    Scene scene = new Scene(pane);
-                    preOpenStage.setScene(scene);
-                    preOpenStage.initStyle(StageStyle.UNDECORATED);
-
-                    preOpenStage.toFront();
-                    preOpenStage.setAlwaysOnTop(true);
-                    preOpenStage.showAndWait();
+                    JFXUtil.loadPreOpenDialog(preOpenStage, root);
                     latch.countDown();
                 });
                 latch.await();

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ErrorAlertConsumer.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ErrorAlertConsumer.java
@@ -31,7 +31,7 @@ public class ErrorAlertConsumer {
                            .filter(s -> s.getTitle().contains(errorMessage.getArchiveInfo().getArchivePath()))
                            .findFirst()
                            .orElse(null);
-            System.out.println(rootStage);
+
             Platform.runLater(() -> {
                 raiseAlert(
                         Alert.AlertType.ERROR,

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
@@ -8,13 +8,17 @@ import com.ntak.pearlzip.archive.pub.FileInfo;
 import com.ntak.pearlzip.archive.pub.ProgressMessage;
 import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import javafx.collections.FXCollections;
+import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import javafx.stage.Window;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -70,7 +74,11 @@ public class JFXUtil {
             alert.getDialogPane().setExpandableContent(vbox);
         }
         ((Stage)alert.getDialogPane().getScene().getWindow()).setAlwaysOnTop(true);
-        return alert.showAndWait();
+        try {
+            return alert.showAndWait();
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 
     public static void changeButtonPicText(ButtonBase button, String imgResource, String labelText) {
@@ -163,5 +171,16 @@ public class JFXUtil {
         });
 
         launchProgress(sessionId, parent, latch, callback);
+    }
+
+    public static void loadPreOpenDialog(Stage stage, Node root) {
+        AnchorPane pane = new AnchorPane(root);
+        Scene scene = new Scene(pane);
+        stage.setScene(scene);
+        stage.initStyle(StageStyle.UNDECORATED);
+
+        stage.toFront();
+        stage.setAlwaysOnTop(true);
+        stage.showAndWait();
     }
 }

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/MoveInArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/MoveInArchiveTestFX.java
@@ -449,7 +449,7 @@ public class MoveInArchiveTestFX extends AbstractPearlZipTestFX {
         clickOn(fileContentsView, MouseButton.SECONDARY);
         sleep(5, MILLISECONDS);
         clickOn("#mnuDrop");
-        sleep(5, MILLISECONDS);
+        sleep(300, MILLISECONDS);
 
         FXArchiveInfo info = lookupArchiveInfo(archiveName).get();
         Assertions.assertEquals(1,

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
@@ -11,8 +11,8 @@ import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import com.ntak.pearlzip.ui.model.ZipState;
 import com.ntak.pearlzip.ui.pub.FrmAboutController;
 import com.ntak.pearlzip.ui.pub.FrmMainController;
+import com.ntak.pearlzip.ui.pub.MacZipLauncher;
 import com.ntak.pearlzip.ui.pub.SysMenuController;
-import com.ntak.pearlzip.ui.pub.ZipLauncher;
 import com.ntak.testfx.ExpectationFileVisitor;
 import com.ntak.testfx.FormUtil;
 import com.ntak.testfx.NativeFileChooserUtil;
@@ -449,9 +449,11 @@ public class PearlZipFXUtil {
 
         // Load main form
         FXMLLoader loader = new FXMLLoader();
-        loader.setLocation(ZipLauncher.class.getResource("/frmMain.fxml"));
+        loader.setLocation(MacZipLauncher.class.getResource("/frmMain.fxml"));
         loader.setResources(LOG_BUNDLE);
         Parent root = loader.load();
+        if (!stage.getStyle().equals(StageStyle.DECORATED))
+            stage.initStyle(StageStyle.DECORATED);
         stage.setScene(new Scene(root));
         FrmMainController controller = loader.getController();
 
@@ -476,7 +478,7 @@ public class PearlZipFXUtil {
 
         // Setting about form...
         FXMLLoader aboutLoader = new FXMLLoader();
-        aboutLoader.setLocation(ZipLauncher.class.getClassLoader().getResource("frmAbout.fxml"));
+        aboutLoader.setLocation(MacZipLauncher.class.getClassLoader().getResource("frmAbout.fxml"));
         aboutLoader.setResources(LOG_BUNDLE);
         VBox abtRoot = aboutLoader.load();
         FrmAboutController abtController = aboutLoader.getController();
@@ -491,7 +493,7 @@ public class PearlZipFXUtil {
 
         // Add some more Menus...
         FXMLLoader menuLoader = new FXMLLoader();
-        menuLoader.setLocation(ZipLauncher.class.getClassLoader().getResource("sysmenu.fxml"));
+        menuLoader.setLocation(MacZipLauncher.class.getClassLoader().getResource("sysmenu.fxml"));
         menuLoader.setResources(LOG_BUNDLE);
         MenuBar additionalMenu = menuLoader.load();
         SysMenuController menuController = menuLoader.getController();


### PR DESCRIPTION
+ Split out JavaFX MacOS specific code from the main launcher to enable AWT to pick up file requests
+ ArchiveUtil - Pulled out common code
+ Mac JavaFX App can handle opening encrypted files (using pre Open dialogs) by double clicking
+ ErrorAlertConsumer - Removed unnecessary println

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>