### PR TITLE
PZ-95,PZ-107 | Fail clear cache when a long-running process is active; Arbitrary single file (non-tarball) compressor archive creation

### DIFF
--- a/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
+++ b/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
@@ -244,6 +244,9 @@ body.ntak.pearl-zip.skip-add-self=Ignoring the addition of file %s into the arch
 title.ntak.pearl-zip.no-compressor-write-services=Warning: No write service available
 body.ntak.pearl-zip.no-compressor-write-services=This functionality is disabled as no compressor write service is available.
 
+title.ntak.pearl-zip.clear-cache-blocked=Clear Cache Blocked
+body.ntak.pearl-zip.clear-cache-blocked=The clear cache process will be cancelled as there are some long running zip tasks in progress.
+
 ###################################################################################################
 ######################################## LABEL TEXT KEYS ##########################################
 ###################################################################################################

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -13,6 +13,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  *  General logging, configuration keys and other shared resources for the JavaFX UI.
@@ -35,6 +37,7 @@ public class ZipConstants {
     public static final String CNS_WINDOW_WIDTH = "configuration.ntak.pearl-zip.window-width";
     public static final String CNS_THREAD_POOL_SIZE = "configuration.ntak.pearl-zip.thread-pool-size";
     public static final String CNS_METRIC_FACTORY = "configuration.ntak.pearl-zip.metric-factory";
+    public static final String CNS_CONCURRENCY_LOCK_POLL_TIMEOUT = "configuration.ntak.pearl-zip.concurrency.lock-poll-timeout";
 
     public static final String LOG_ARCHIVE_CAN_EXTRACT = "logging.ntak.pearl-zip.tar-can-extract";
     public static final String LOG_CLICKED_ROW = "logging.ntak.pearl-zip.clicked-row";
@@ -225,6 +228,9 @@ public class ZipConstants {
     public static final String TITLE_NO_COMPRESSOR_WRITE_SERVICES = "title.ntak.pearl-zip.no-compressor-write-services";
     public static final String BODY_NO_COMPRESSOR_WRITE_SERVICES = "body.ntak.pearl-zip.no-compressor-write-services";
 
+    public static final String TITLE_CLEAR_CACHE_BLOCKED = "title.ntak.pearl-zip.clear-cache-blocked";
+    public static final String BODY_CLEAR_CACHE_BLOCKED = "body.ntak.pearl-zip.clear-cache-blocked";
+
     public static final String LOG_INVALID_ARCHIVE_SETUP = "logging.ntak.pearl-zip.invalid-archive-setup";
 
     public static final String LOG_ISSUE_SAVE_ARCHIVE = "logging.ntak.pearl-zip.issue-save-archive";
@@ -268,4 +274,6 @@ public class ZipConstants {
     public static ErrorAlertConsumer ERROR_ALERT_CONSUMER;
     public static MenuToolkit MENU_TOOLKIT;
     public static Path RUNTIME_MODULE_PATH;
+
+    public static final ReadWriteLock LCK_CLEAR_CACHE = new ReentrantReadWriteLock(true);
 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
@@ -26,6 +26,8 @@ public class ZipState {
 
     public static final int WIDTH = Integer.parseInt(System.getProperty(CNS_WINDOW_WIDTH, "816"));
     public static final int HEIGHT = Integer.parseInt(System.getProperty(CNS_WINDOW_HEIGHT, "480"));
+    public static final long LOCK_POLL_TIMEOUT = Integer.parseInt(System.getProperty(CNS_CONCURRENCY_LOCK_POLL_TIMEOUT,
+                                                                               "100"));
     public static final AtomicBoolean ROW_TRIGGER = new AtomicBoolean(false);
     public static final CopyOnWriteArrayList<ContextMenu> CONTEXT_MENU_INSTANCES = new CopyOnWriteArrayList<>();
 

--- a/pearl-zip-ui/src/main/resources/application.properties
+++ b/pearl-zip-ui/src/main/resources/application.properties
@@ -13,3 +13,4 @@ configuration.ntak.pearl-zip.weblink=https://pearlzip.92ak.co.uk
 configuration.ntak.pearl-zip.license-location=LICENSE.xml
 configuration.ntak.pearl-zip.license-override-location=LICENSE-OVERRIDE.xml
 configuration.ntak.pearl-zip.commit-hash=:: HASH ::
+configuration.ntak.pearl-zip.concurrency.lock-poll-timeout=100

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/pub/FrmMainControllerTest.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/pub/FrmMainControllerTest.java
@@ -10,10 +10,7 @@ import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import com.ntak.pearlzip.ui.model.ZipState;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
-import javafx.scene.control.Button;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
+import javafx.scene.control.*;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -43,7 +40,7 @@ public class FrmMainControllerTest {
     private static TableColumn<FileInfo, FileInfo> hash;
     private static TableColumn<FileInfo, FileInfo> comments;
     
-    private static Button btnNew;
+    private static MenuButton btnNew;
     private static Button btnOpen;
     private static MenuButton btnAdd;
     private static MenuButton btnExtract;
@@ -87,8 +84,8 @@ public class FrmMainControllerTest {
             mockArchiveInfo = Mockito.mock(FXArchiveInfo.class);
 
             // Initialise common stubbing
-            when(mockReadService.supportedReadFormats()).thenReturn(List.of("zip","tar.gz"));
-            when(mockWriteService.supportedWriteFormats()).thenReturn(List.of("zip","tar.gz"));
+            when(mockReadService.supportedReadFormats()).thenReturn(List.of("zip","gz"));
+            when(mockWriteService.supportedWriteFormats()).thenReturn(List.of("zip","gz"));
             when(mockReadService.getCompressorArchives()).thenCallRealMethod();
             when(mockWriteService.getCompressorArchives()).thenCallRealMethod();
             when(mockArchiveInfo.getReadService()).thenReturn(mockReadService);
@@ -103,7 +100,9 @@ public class FrmMainControllerTest {
             hash = new TableColumn<>();
             comments = new TableColumn<>();
 
-            btnNew = new Button();
+            MenuItem mnuNewSingleFileCompressor = new MenuItem();
+            mnuNewSingleFileCompressor.setId("mnuNewSingleFileCompressor");
+            btnNew = new MenuButton(null,null, mnuNewSingleFileCompressor);
             btnOpen = new Button();
             btnAdd = new MenuButton();
             btnExtract = new MenuButton();

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
@@ -162,18 +162,19 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                               "Temp file was not initialised");
 
         // Open existing archive in current window
-        clickOn(Point2D.ZERO.add(110, 10)).clickOn(Point2D.ZERO.add(110, 80));
+        clickOn(Point2D.ZERO.add(110, 10))
+                .clickOn(Point2D.ZERO.add(110, 80));
         final Path archivePath = Paths.get("src", "test", "resources", "test.zip")
                                       .toAbsolutePath();
         // Via Sys menu
         simOpenArchive(this, archivePath, false, false);
-        sleep(50, TimeUnit.MILLISECONDS);
+        sleep(500, TimeUnit.MILLISECONDS);
         Assertions.assertTrue(lookupArchiveInfo(archivePath.getFileName().toString()).isPresent(),"Expected archive " +
                 "was not present");
 
         DialogPane dialogPane = lookup(".dialog-pane").query();
         clickOn(dialogPane.lookupButton(ButtonType.NO));
-        sleep(50, MILLISECONDS);
+        sleep(250, MILLISECONDS);
 
         // Navigate to the clear cache option
         this.clickOn(Point2D.ZERO.add(160, 10))


### PR DESCRIPTION
PZ-95:
+ Implemented locking functionality to ensure that the clear cache process takes exclusive priority over any zip modification processes to ensure expected behaviour when performing those zip operations

PZ-107:
+ Fixed breaking unit test because of change

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>