### PR TITLE
PZ-147 | Ordering of archive grid is not as expected

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../Zip4j-PearlZip-Plugin" vcs="Git" />
   </component>
 </project>

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmMainController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmMainController.java
@@ -94,11 +94,13 @@ public class FrmMainController {
 
         modified.setCellFactory(new ModifiedHighlightFileInfoCellCallback());
         modified.setCellValueFactory(new PropertyValueFactory<>("Self"));
-        modified.setComparator((v,w) -> Optional.ofNullable(v.getLastWriteTime()).orElse(LocalDateTime.MIN).compareTo(Optional.ofNullable(w.getLastWriteTime()).orElse(LocalDateTime.MAX)));
+        modified.setComparator(Comparator.comparing(v -> Optional.ofNullable(v.getLastWriteTime())
+                                                                 .orElse(LocalDateTime.MIN)));
 
         created.setCellFactory(new CreatedHighlightFileInfoCellCallback());
         created.setCellValueFactory(new PropertyValueFactory<>("Self"));
-        created.setComparator((v,w) -> Optional.ofNullable(v.getCreationTime()).orElse(LocalDateTime.MIN).compareTo(Optional.ofNullable(w.getCreationTime()).orElse(LocalDateTime.MAX)));
+        created.setComparator(Comparator.comparing(v -> Optional.ofNullable(v.getCreationTime())
+                                                                .orElse(LocalDateTime.MIN)));
 
         hash.setCellFactory(new HashHighlightFileInfoCellCallback());
         hash.setCellValueFactory(new PropertyValueFactory<>("Self"));
@@ -137,6 +139,7 @@ public class FrmMainController {
                         CONTEXT_MENU_INSTANCES.forEach(ContextMenu::hide);
                         CONTEXT_MENU_INSTANCES.clear();
                     }
+                    fileContentsView.refresh();
                     return;
                 }
 


### PR DESCRIPTION
PZ-147:
+ Updating grid to ensure ordering is more stable when non-comparable are displayed

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>