### PR TITLE
PZ-164 | Java OpenJDK 17 LTS Migration (PearlZip and Zip4j Plugin)

### DIFF
--- a/pearl-zip-archive-szjb/pom.xml
+++ b/pearl-zip-archive-szjb/pom.xml
@@ -28,11 +28,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>net.sf.sevenzipjbinding</groupId>
+            <groupId>com.ntak</groupId>
             <artifactId>sevenzipjbinding</artifactId>
             <version>16.02-2.01</version>
-            <systemPath>${basedir}/lib/sevenzipjbinding-16.02-2.01.jar</systemPath>
-            <scope>system</scope>
         </dependency>
         <dependency>
             <groupId>com.ntak</groupId>
@@ -81,4 +79,38 @@
             </build>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>mvn</executable>
+                    <arguments>
+                        <argument>install:install-file</argument>
+                        <argument>-Dfile=${project.basedir}/lib/sevenzipjbinding-16.02-2.01.jar</argument>
+                        <argument>-DgroupId=com.ntak</argument>
+                        <argument>-DartifactId=sevenzipjbinding</argument>
+                        <argument>-Dversion=16.02-2.01</argument>
+                        <argument>-Dpackaging=jar</argument>
+                        <argument>-DgeneratePom=true</argument>
+                    </arguments>
+                    <async>false</async>
+                </configuration>
+                <goals>
+                    <goal>exec</goal>
+                </goals>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pearl-zip-license/src/main/resources/LICENSE-OVERRIDE.xml
+++ b/pearl-zip-license/src/main/resources/LICENSE-OVERRIDE.xml
@@ -6,7 +6,7 @@
 <licenseSummary>
     <dependencies>
         <dependency>
-            <groupId>net.sf.sevenzipjbinding</groupId>
+            <groupId>com.ntak</groupId>
             <artifactId>sevenzipjbinding</artifactId>
             <version>16.02-2.01</version>
             <licenses>

--- a/pearl-zip-ui/pom.xml
+++ b/pearl-zip-ui/pom.xml
@@ -73,11 +73,9 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.sevenzipjbinding</groupId>
-            <artifactId>sevenzipjbinding-all-platforms</artifactId>
+            <groupId>com.ntak</groupId>
+            <artifactId>sevenzipjbinding</artifactId>
             <version>16.02-2.01</version>
-            <systemPath>${basedir}/../pearl-zip-archive-szjb/lib/sevenzipjbinding-16.02-2.01.jar</systemPath>
-            <scope>system</scope>
         </dependency>
         <dependency>
             <groupId>com.ntak</groupId>


### PR DESCRIPTION
+ SevenZipJBinding java module has been installed in repository as an alternative to system reference to handle downstream dependencies.

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>