### PR TITLE
PZ-177 | Prevent parent archive from closing when integrated archive is open

### DIFF
--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/DeleteInArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/DeleteInArchiveTestFX.java
@@ -56,7 +56,11 @@ public class DeleteInArchiveTestFX extends AbstractPearlZipTestFX {
         for (Path dir :
                 Files.list(dir.getParent().getParent()).filter(p->p.getFileName().toString().startsWith("pz")).collect(
                         Collectors.toList())) {
-            UITestSuite.clearDirectory(dir);
+            try {
+                UITestSuite.clearDirectory(dir);
+            } catch(Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
+ DeleteInArchiveTestFX - Updated tear down to catch issue with clear directory so tests don't fail on clean up failure

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>