### PR TITLE
PZ-178 | Set plugin usage priority in the providers options tab

### DIFF
--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ArchiveConstants.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ArchiveConstants.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 public class ArchiveConstants {
     public static final Properties CURRENT_SETTINGS = new Properties();
     public static final Properties WORKING_SETTINGS = new Properties();
+    public static final Properties WORKING_APPLICATION_SETTINGS = new Properties();
     public static final List<Predicate<ArchiveInfo>> NEW_ARCHIVE_VALIDATORS = new CopyOnWriteArrayList<>();
 
     public static final ThreadGroup EVENTBUS_THREAD_GROUP = new ThreadGroup("EVENTBUS-THREAD-GROUP");

--- a/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
+++ b/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
@@ -385,6 +385,7 @@ options.bootstrap-properties.key.text=Key
 options.bootstrap-properties.value.text=Value
 options.providers.text=Providers
 options.providers.name.text=Provider Name
+options.providers.name.priority.text=Priority
 options.providers.name.readCapability.text=Read Capability
 options.providers.name.writeCapability.text=Write Capability
 options.providers.name.supportedFormat.text=Supported Formats

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -315,6 +315,7 @@ public class ZipConstants {
     public static Path STORE_TEMP;
     public static Path RECENT_FILE;
     public static Path SETTINGS_FILE;
+    public static Path APPLICATION_SETTINGS_FILE;
     public static ExecutorService PRIMARY_EXECUTOR_SERVICE;
     public static ThreadGroup THREAD_GROUP;
     public static ProgressMessageTraceLogger MESSAGE_TRACE_LOGGER;

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
@@ -63,19 +63,29 @@ public class ZipState {
                                                  .collect(Collectors.toSet())
         );
         if (service instanceof  ArchiveWriteService) {
-            addArchiveToMap(ARCHIVE_WRITE_MAP, ((ArchiveWriteService)service).supportedWriteFormats()
-                                                                             .stream()
-                                                                             .filter(Strings::isNotBlank)
-                                                                             .collect(Collectors.toList()),
+            addArchiveToMap(ARCHIVE_WRITE_MAP, ((ArchiveWriteService) service).supportedWriteFormats()
+                                                                              .stream()
+                                                                              .filter(Strings::isNotBlank)
+                                                                              .collect(Collectors.toList()),
                             (ArchiveWriteService) service);
+
+            WRITE_PROVIDERS.removeIf(s -> s.getClass()
+                                           .getCanonicalName()
+                                           .equals(service.getClass()
+                                                          .getCanonicalName()));
             WRITE_PROVIDERS.add((ArchiveWriteService) service);
         }
         if (service instanceof ArchiveReadService) {
-            addArchiveToMap(ARCHIVE_READ_MAP, ((ArchiveReadService)service).supportedReadFormats()
-                                                                           .stream()
-                                                                           .filter(Strings::isNotBlank)
-                                                                           .collect(Collectors.toList()),
+            addArchiveToMap(ARCHIVE_READ_MAP, ((ArchiveReadService) service).supportedReadFormats()
+                                                                            .stream()
+                                                                            .filter(Strings::isNotBlank)
+                                                                            .collect(Collectors.toList()),
                             (ArchiveReadService) service);
+
+            READ_PROVIDERS.removeIf(s -> s.getClass()
+                                          .getCanonicalName()
+                                          .equals(service.getClass()
+                                                         .getCanonicalName()));
             READ_PROVIDERS.add((ArchiveReadService) service);
         }
     }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
@@ -74,7 +74,7 @@ public class ZipLauncher {
         ZipConstants.LOCAL_TEMP =
                 Paths.get(Optional.ofNullable(System.getenv("TMPDIR"))
                                   .orElse(STORE_ROOT.toString()));
-        Path externalBootstrapFile = Paths.get(STORE_ROOT.toString(), "application.properties");
+        APPLICATION_SETTINGS_FILE = Paths.get(STORE_ROOT.toString(), "application.properties");
 
         String defaultModulePath = Path.of(STORE_ROOT.toAbsolutePath().toString(), "providers").toString();
         ZipConstants.RUNTIME_MODULE_PATH =
@@ -119,15 +119,17 @@ public class ZipLauncher {
                     Files.copy(reservedKeys, tmpRK, StandardCopyOption.REPLACE_EXISTING);
                 }
 
-                Files.lines(tmpRK)
+            Files.lines(tmpRK)
                  .filter(k -> Objects.nonNull(k) && Objects.nonNull(props.getProperty(k)))
                  // LOG: Locking in key: %s with value: %s
-                 .peek(k -> LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOCKING_IN_PROPERTY, k, props.getProperty(k))))
+                 .peek(k -> LoggingConstants.ROOT_LOGGER.info(resolveTextKey(LOG_LOCKING_IN_PROPERTY,
+                                                                             k,
+                                                                             props.getProperty(k))))
                  .forEach(k -> reservedKeyMap.put(k, props.getProperty(k)));
         }
 
-        if (Files.exists(externalBootstrapFile)) {
-            props.load(Files.newBufferedReader(externalBootstrapFile));
+        if (Files.exists(APPLICATION_SETTINGS_FILE)) {
+            props.load(Files.newBufferedReader(APPLICATION_SETTINGS_FILE));
         }
 
         props.putAll(System.getProperties());

--- a/pearl-zip-ui/src/main/resources/frmOptions.fxml
+++ b/pearl-zip-ui/src/main/resources/frmOptions.fxml
@@ -37,6 +37,8 @@
                                      text="%options.providers.name.readCapability.text"/>
                         <TableColumn fx:id="writeCapability" prefWidth="68.0"
                                      text="%options.providers.name.writeCapability.text"/>
+                        <TableColumn fx:id="priority" prefWidth="68.0"
+                                     text="%options.providers.name.priority.text"/>
                         <TableColumn fx:id="supportedFormat" prefWidth="163.0"
                                      text="%options.providers.name.supportedFormat.text"/>
                     </columns>


### PR DESCRIPTION
+ Options dialog changes:
  - Added editable field for Priority of plugins for selection as the active provider to read and/or write an archive format.
  - On the providers tab, the capabilities are kept as read only.
+ Ensured only one instance of ArchiveService is stored within ZipState

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>