### PR TITLE
PZ-166,PZ-178 | Comment support (Editable on main archive screen); Set plugin usage priority in the providers options tab

### DIFF
--- a/pearl-zip-archive-acc/src/test/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteServiceTestCore.java
+++ b/pearl-zip-archive-acc/src/test/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteServiceTestCore.java
@@ -266,12 +266,12 @@ public abstract class CommonsCompressArchiveWriteServiceTestCore {
 
         Assertions.assertTrue(Files.exists(archive), "Archive was not created");
         final byte[] bytes = Files.readAllBytes(archive);
-        Assertions.assertEquals(382, bytes.length, "File failed to create in the expected manner");
+        Assertions.assertEquals(22, bytes.length, "File failed to create in the expected manner");
+
         // Zip magic number
         Assertions.assertEquals((byte)0x50, bytes[0], "first byte");
         Assertions.assertEquals((byte)0x4b, bytes[1], "second byte issue");
-        Assertions.assertEquals((byte)0x03, bytes[2], "third byte issue");
-        Assertions.assertEquals((byte)0x04, bytes[3], "fourth byte issue");
+        Assertions.assertTrue((((byte)0x03 == bytes[2]) && ((byte)0x04 == bytes[3])) || (((byte)0x05 == bytes[2]) && ((byte)0x06 == bytes[3])), "third and/or fourth byte issue");
         Assertions.assertNotEquals(beforeHash, afterHash, "The archive was not updated");
     }
 

--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/FileInfo.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/FileInfo.java
@@ -6,6 +6,7 @@ package com.ntak.pearlzip.archive.pub;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  *  Java bean which stores normalised data about a particular entry in a zip archive.
@@ -24,7 +25,7 @@ public class FileInfo {
     private final String user;
     private final String group;
     private final int attributes;
-    private final String comments;
+    private String comments;
     private final boolean isFolder;
     private final boolean isEncrypted;
     private final Map<String,Object> additionalInfoMap;
@@ -49,7 +50,7 @@ public class FileInfo {
         this.comments = comments;
         this.isFolder = isFolder;
         this.isEncrypted = isEncrypted;
-        this.additionalInfoMap = additionalInfoMap;
+        this.additionalInfoMap = new ConcurrentHashMap<>(additionalInfoMap);
     }
 
     public int getIndex() {
@@ -118,6 +119,10 @@ public class FileInfo {
 
     public Map<String,Object> getAdditionalInfoMap() {
         return additionalInfoMap;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
     }
 
     public FileInfo getSelf() { return this; }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallback.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallback.java
@@ -3,17 +3,114 @@
  */
 package com.ntak.pearlzip.ui.cell;
 
+import com.ntak.pearlzip.archive.pub.ArchiveReadService;
+import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
 import com.ntak.pearlzip.archive.pub.FileInfo;
+import com.ntak.pearlzip.ui.constants.ZipConstants;
+import com.ntak.pearlzip.ui.model.FXArchiveInfo;
+import com.ntak.pearlzip.ui.model.ZipState;
+import com.ntak.pearlzip.ui.util.ArchiveUtil;
+import com.ntak.pearlzip.ui.util.JFXUtil;
+import javafx.collections.FXCollections;
+import javafx.scene.control.Alert;
 import javafx.scene.control.TableCell;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.KEY_FILE_PATH;
+import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
+import static com.ntak.pearlzip.ui.constants.ResourceConstants.PATTERN_TEXTFIELD_TABLE_CELL_STYLE;
+import static com.ntak.pearlzip.ui.constants.ZipConstants.BODY_ADD_COMMENT_NOT_SUPPORTED;
+import static com.ntak.pearlzip.ui.constants.ZipConstants.TITLE_ADD_COMMENT_NOT_SUPPORTED;
 
 /**
  *  Implementation of cell renderer for the Comments field.
  *  @author Aashutos Kakshepati
 */
 public class CommentsHighlightFileInfoCellCallback extends AbstractHighlightFileInfoCellCallback {
+
+    private FXArchiveInfo fxArchiveInfo;
+
+    public CommentsHighlightFileInfoCellCallback(FXArchiveInfo fxArchiveInfo) {
+        this.fxArchiveInfo = fxArchiveInfo;
+    }
+
     @Override
     public void setField(TableCell<FileInfo,FileInfo> cell, FileInfo info) {
         String comments = info.getComments();
-        cell.setText(comments);
+
+        TextField textField = new TextField();
+        textField.setText(comments);
+        String color = cell.getTableRow().isSelected() ? "white" : "black";
+        textField.setStyle(String.format(PATTERN_TEXTFIELD_TABLE_CELL_STYLE, color));
+
+        textField.setOnKeyTyped(e -> info.setComments(e.getText()));
+        textField.focusedProperty().addListener((observable,oldVal,newVal) -> {
+            // Commit changes to comments
+            if (oldVal && !newVal) {
+                ArchiveWriteService writeService =
+                        ZipState.getWriteArchiveServiceForFile(fxArchiveInfo.getArchivePath())
+                                .orElse(null);
+                ArchiveReadService readService =
+                        ZipState.getReadArchiveServiceForFile(fxArchiveInfo.getArchivePath())
+                                .orElse(null);
+
+                long sessionId = System.currentTimeMillis();
+                if (Objects.nonNull(writeService) && Objects.nonNull(readService)) {
+                    Path tempFile = Paths.get(ZipConstants.STORE_TEMP.toAbsolutePath()
+                                                                     .toString(),
+                                              String.format("pz%s", sessionId),
+                                              info.getFileName()
+                    );
+                    try {
+                        Files.createDirectories(tempFile.getParent());
+                        Files.createFile(tempFile);
+
+                        if (readService.extractFile(sessionId, tempFile, fxArchiveInfo.getArchiveInfo(), info)) {
+                            // Remove file...
+                            sessionId = System.currentTimeMillis();
+                            writeService.deleteFile(sessionId, fxArchiveInfo.getArchiveInfo(), info);
+
+                            // Rewrite file into archive...
+                            sessionId = System.currentTimeMillis();
+                            info.setComments(textField.getText());
+                            info.getAdditionalInfoMap().put(KEY_FILE_PATH, tempFile.toAbsolutePath().toString());
+                            writeService.addFile(sessionId, fxArchiveInfo.getArchiveInfo(), info);
+                        }
+                    } catch(IOException e) {
+                    } finally {
+                        sessionId = System.currentTimeMillis();
+                        ArchiveUtil.deleteDirectory(tempFile.getParent(), (f)->false);
+                        final TableView<FileInfo> fileContentsView = fxArchiveInfo.getController()
+                                                                                  .get()
+                                                                                  .getFileContentsView();
+                        fileContentsView.setItems(FXCollections.observableArrayList(readService.listFiles(sessionId,
+                                                                                                          fxArchiveInfo.getArchiveInfo()
+                                                  ))
+                        );
+                        JFXUtil.refreshFileView(fileContentsView,
+                                                fxArchiveInfo,
+                                                fxArchiveInfo.getDepth().get(),
+                                                fxArchiveInfo.getPrefix());
+
+                    }
+                }  else {
+                    // TITLE: Add comment functionality not supported for archive %s
+                    // BODY: No Write provider for archive format
+                    JFXUtil.raiseAlert(Alert.AlertType.ERROR,
+                                       resolveTextKey(TITLE_ADD_COMMENT_NOT_SUPPORTED),
+                                       null,
+                                       resolveTextKey(BODY_ADD_COMMENT_NOT_SUPPORTED),
+                                       null);
+                }
+            }
+        });
+        cell.setGraphic(textField);
     }
 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ResourceConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ResourceConstants.java
@@ -35,6 +35,10 @@ public class ResourceConstants {
     public static final String PATTERN_FXID_NEW_OPTIONS = "%s.new-options";
     public static final String PATTERN_FXID_OPTIONS = "%s.options";
 
+    public static final String PATTERN_TEXTFIELD_TABLE_CELL_STYLE = "-fx-text-box-border: transparent; -fx-background-color: transparent; " +
+            "-fx-background-insets: 0; -fx-padding: 1 3 1 3; -fx-focus-color: transparent; " +
+            "-fx-text-fill: %s;";
+
     public static final int NO_FILES_HISTORY = Integer.parseInt(System.getProperty(CNS_NTAK_PEARL_ZIP_NO_FILES_HISTORY,
                                                                                    "5"));
     public static Menu WINDOW_MENU;

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -263,6 +263,9 @@ public class ZipConstants {
     public static final String TITLE_CONFIRM_LOAD_PROVIDER_MODULE = "title.ntak.pearl-zip.confirm-load-provider-module";
     public static final String BODY_CONFIRM_LOAD_PROVIDER_MODULE = "body.ntak.pearl-zip.confirm-load-provider-module";
 
+    public static final String TITLE_ADD_COMMENT_NOT_SUPPORTED = "title.ntak.pearl-zip.add-comments.not-supported";
+    public static final String BODY_ADD_COMMENT_NOT_SUPPORTED = "body.ntak.pearl-zip.add-comments.not-supported";
+
     public static final String LOG_ISSUE_ADD_DRAG_DROP = "logging.ntak.pearl-zip.issue-add-drag-drop";
     public static final String TITLE_ISSUE_ADD_DRAG_DROP = "title.ntak.pearl-zip.issue-add-drag-drop";
     public static final String HEADER_ISSUE_ADD_DRAG_DROP = "header.ntak.pearl-zip.issue-add-drag-drop";

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_BUNDLE;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
+import static com.ntak.pearlzip.ui.constants.ResourceConstants.PATTERN_TEXTFIELD_TABLE_CELL_STYLE;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
 import static com.ntak.pearlzip.ui.model.ZipState.CONTEXT_MENU_INSTANCES;
 import static com.ntak.pearlzip.ui.model.ZipState.ROW_TRIGGER;
@@ -67,6 +68,21 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
     public void handle(MouseEvent event) {
             if (Objects.nonNull(row.getItem())) {
                 ROW_TRIGGER.set(true);
+            }
+
+            if (!row.isEmpty()) {
+                final int focusedIndex = fileContentsView.getSelectionModel()
+                                                         .getFocusedIndex();
+                for (int i = 0; i < fileContentsView.getItems().size(); i++) {
+                    int curIdx = i;
+                    JFXUtil.getTableCellForColumnRow(fileContentsView, i, "Comments").ifPresent(
+                            (tabCell) -> {
+                                String colour = curIdx == focusedIndex ? "white":"black";
+                                tabCell.getGraphic().setStyle(String.format(PATTERN_TEXTFIELD_TABLE_CELL_STYLE,
+                                                                            colour));
+                            }
+                    );
+                }
             }
 
             if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmMainController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmMainController.java
@@ -109,17 +109,18 @@ public class FrmMainController {
         hash.setCellValueFactory(new PropertyValueFactory<>("Self"));
         hash.setComparator(Comparator.comparing(v -> Long.toHexString(v.getCrcHash())
                                                          .toUpperCase()));
-
-        comments.setCellFactory(new CommentsHighlightFileInfoCellCallback());
-        comments.setCellValueFactory(new PropertyValueFactory<>("Self"));
-        comments.setComparator(Comparator.comparing(v -> Optional.ofNullable(v.getComments())
-                                                                 .orElse("")));
     }
 
     public void initData(Stage stage, FXArchiveInfo fxArchiveInfo) {
         if (fxArchiveInfo != null) {
             this.FXArchiveInfo = fxArchiveInfo;
             stage.setUserData(fxArchiveInfo);
+
+            comments.setCellFactory(new CommentsHighlightFileInfoCellCallback(fxArchiveInfo));
+            comments.setCellValueFactory(new PropertyValueFactory<>("Self"));
+            comments.setComparator(Comparator.comparing(v -> Optional.ofNullable(v.getComments())
+                                                                     .orElse("")));
+
             // TODO: Handle multiple rows
             fileContentsView.getSelectionModel()
                             .setSelectionMode(SelectionMode.SINGLE);
@@ -254,7 +255,7 @@ public class FrmMainController {
                                                                        .findFirst();
                      if (!oldValue && newValue) {
                          synchronized(WINDOW_MENU) {
-                             if (!optMenuItem.isPresent()) {
+                             if (optMenuItem.isEmpty()) {
                                  MenuItem archiveMenuItem = new MenuItem(String.format("%s%s",
                                                                                        fxArchiveInfo.getArchivePath(),
                                                                                        WINDOW_FOCUS_SYMBOL));
@@ -275,9 +276,9 @@ public class FrmMainController {
 
                      if (oldValue && !newValue) {
                          synchronized(WINDOW_MENU) {
-                             optMenuItem.ifPresent(m -> m.setText(String.format(m.getText()
-                                                                                 .replaceAll(WINDOW_FOCUS_SYMBOL
-                                                                                         , ""))));
+                             optMenuItem.ifPresent(m -> m.setText(m.getText()
+                                                                   .replaceAll(WINDOW_FOCUS_SYMBOL
+                                                                                         , "")));
                          }
                      }
                  });
@@ -327,6 +328,10 @@ public class FrmMainController {
 
     public Button getBtnUp() {
         return btnUp;
+    }
+
+    public TableColumn<FileInfo,FileInfo> getComments() {
+        return comments;
     }
 
     public FXArchiveInfo getFXArchiveInfo() {

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
@@ -8,6 +8,7 @@ import com.ntak.pearlzip.archive.pub.ArchiveService;
 import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
 import com.ntak.pearlzip.ui.model.ZipState;
 import com.ntak.pearlzip.ui.util.ClearCacheRunnable;
+import com.ntak.pearlzip.ui.util.JFXUtil;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 import static com.ntak.pearlzip.archive.constants.ArchiveConstants.*;
 import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
 import static com.ntak.pearlzip.ui.constants.ResourceConstants.PATTERN_FXID_OPTIONS;
+import static com.ntak.pearlzip.ui.constants.ResourceConstants.PATTERN_TEXTFIELD_TABLE_CELL_STYLE;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
 import static com.ntak.pearlzip.ui.util.ArchiveUtil.initialiseApplicationSettings;
 import static com.ntak.pearlzip.ui.util.JFXUtil.executeBackgroundProcess;
@@ -207,6 +209,8 @@ public class FrmOptionsController {
                 } else {
                     TextField textField = new TextField();
                     textField.setText(String.valueOf(item.getValue()));
+                    String color = this.getTableRow().isSelected() ? "white" : "black";
+                    textField.setStyle(String.format(PATTERN_TEXTFIELD_TABLE_CELL_STYLE, color));
 
                     textField.setOnKeyTyped(e -> {
                         char charEntered = e.getCode()
@@ -273,7 +277,20 @@ public class FrmOptionsController {
                                 .map(s -> new Pair<Boolean,ArchiveService>(false, s))
                                 .collect(Collectors.toList()));
         tblProviders.setItems(FXCollections.observableArrayList(services));
-
+        tblProviders.setOnMouseClicked(e->{
+            final int focusedIndex = tblProviders.getSelectionModel()
+                                                     .getFocusedIndex();
+            for (int i = 0; i < tblProviders.getItems().size(); i++) {
+                final int curIdx = i;
+                JFXUtil.getTableCellForColumnRow(tblProviders, i, "Priority").ifPresent(
+                        (tabCell) -> {
+                            String colour = curIdx == focusedIndex ? "white":"black";
+                            tabCell.getGraphic().setStyle(String.format(PATTERN_TEXTFIELD_TABLE_CELL_STYLE,
+                                                                        colour));
+                        }
+                );
+            }
+        });
         for (ArchiveService service : services.stream()
                                               .map(Pair::getValue)
                                               .collect(Collectors.toList())) {

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
@@ -12,6 +12,7 @@ import com.ntak.pearlzip.ui.pub.ZipLauncher;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
@@ -276,5 +277,24 @@ public class JFXUtil {
         int offsetHeight = (Integer) engine.executeScript("document.documentElement.offsetHeight");
         boolean isScrollBottom = scrollY + innerHeight + (innerHeight * (innerHeight / offsetHeight)) >= scrollHeight;
         callback.accept(isScrollBottom);
+    }
+
+    public static <S> Optional<TableCell<S,?>> getTableCellForColumnRow(TableView<S> table, int rowIndex,
+            String columnName) {
+        Integer columnIndex = table.getColumns()
+                    .indexOf(table.getColumns()
+                                         .stream()
+                                         .filter(c -> c.getText().equals(columnName))
+                                         .findFirst()
+                                         .orElse(null));
+        if (Objects.nonNull(columnIndex)) {
+            Object obj = table.queryAccessibleAttribute(AccessibleAttribute.CELL_AT_ROW_COLUMN, rowIndex, columnIndex);
+
+            if (obj instanceof TableCell tc) {
+                return Optional.ofNullable((TableCell<S,?>) tc);
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallbackTest.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallbackTest.java
@@ -3,20 +3,36 @@
  */
 package com.ntak.pearlzip.ui.cell;
 
+import com.ntak.pearlzip.archive.pub.ArchiveReadService;
+import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
 import com.ntak.pearlzip.archive.pub.FileInfo;
+import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.control.TableCell;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TextField;
 import org.junit.jupiter.api.*;
+import org.mockito.internal.util.reflection.InstanceField;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 
+import static org.mockito.Mockito.mock;
+
 @Tag("Excluded")
 public class CommentsHighlightFileInfoCellCallbackTest {
 
-    CommentsHighlightFileInfoCellCallback callback = new CommentsHighlightFileInfoCellCallback();
+    public static CommentsHighlightFileInfoCellCallback callback;
     private static CountDownLatch latch = new CountDownLatch(1);
+
+    static TableCell<FileInfo,FileInfo> cell;
+    static TableRow<FileInfo> row;
 
     /*
          Test cases:
@@ -24,13 +40,25 @@ public class CommentsHighlightFileInfoCellCallbackTest {
      */
 
     @BeforeAll
-    public static void setUpOnce() throws InterruptedException {
+    public static void setUpOnce() throws InterruptedException, IOException {
         try {
-            Platform.startup(() -> latch.countDown());
+            Platform.startup(() -> {
+                cell = new TableCell<>();
+                row = new TableRow<>();
+                latch.countDown();
+            });
         } catch (Exception e) {
             latch.countDown();
         } finally {
             latch.await();
+
+            Path tmpFile = Files.createTempFile("tmp", ".zip");
+            ArchiveReadService mockReadService = mock(ArchiveReadService.class);
+            ArchiveWriteService mockWriteService = mock(ArchiveWriteService.class);
+            FXArchiveInfo fxArchiveInfo = new FXArchiveInfo(tmpFile.toAbsolutePath().toString(),
+                                                            mockReadService,
+                                                            mockWriteService);
+            callback = new CommentsHighlightFileInfoCellCallback(fxArchiveInfo);
         }
     }
 
@@ -41,11 +69,17 @@ public class CommentsHighlightFileInfoCellCallbackTest {
 
     @Test
     @DisplayName("Test: Set Comments field successfully")
-    public void testSetField_ValidParameters_Success() {
-        final TableCell<FileInfo,FileInfo> cell = new TableCell<>();
+    public void testSetField_ValidParameters_Success() throws NoSuchFieldException {
+        final Field fieldRow = TableCell.class.getDeclaredField("tableRow");
+        fieldRow.setAccessible(true);
+        InstanceField fieldROTableRow = new InstanceField(fieldRow,
+                                                          cell);
+        fieldROTableRow.set(new ReadOnlyObjectWrapper(row));
+
         FileInfo info = new FileInfo(0, 0, "filename", 0, 0, 0, LocalDateTime.now(), LocalDateTime.now(),
                                      LocalDateTime.now(), "user", "group", 0, "some comments", false, false, Collections.emptyMap());
         callback.setField(cell, info);
-        Assertions.assertEquals("some comments", cell.getText(), "Fields were not set as expected");
+        Assertions.assertEquals("some comments", ((TextField)cell.getGraphic()).getText(), "Fields were not set as " +
+                "expected");
     }
 }


### PR DESCRIPTION
PZ-166:
+ FileInfo - Additional properties map is now mutable
+ CommonsCompressArchiveWriteService - Handles the persistence of Comments for zip-based archives
+ CommentsHighlightFileInfoCellCallback - Added comments persist functionality and beautification of cell presentation
+ FileInfoRowEventHandler - Beautification of cell presentation when changing rows
+ FrmMainController - Handle updated comments functionality
+ JFXUtil - Utility method to retrieve table cell by row index and column
+ Unit test updates

PZ-178
+ FrmOptionsController - Beautification of priority cell functionality inline with the comments table cell layout above

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>