### PR TITLE
PZ-166,PZ-161 | Comment support (Editable on main archive screen); Generic JavaFX Node hooks retrieval logic

### DIFF
--- a/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteService.java
+++ b/pearl-zip-archive-acc/src/main/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteService.java
@@ -240,32 +240,21 @@ public class CommonsCompressArchiveWriteService implements ArchiveWriteService {
     }
 
     private void prepareStreamEntry(ArchiveEntry entry) {
-        if (entry instanceof JarArchiveEntry jae) {
-            final byte[] bytComment = Arrays.stream(jae.getExtraFields())
-                                                   .filter(UnicodeCommentExtraField.class::isInstance)
-                                                   .findFirst()
-                                                   .get()
-                                                   .getLocalFileDataData();
-
-            if (bytComment.length > 5) {
-                String comment = StandardCharsets.UTF_8.decode(ByteBuffer.wrap((Arrays.copyOfRange(bytComment, 5,
-                                                                                                   bytComment.length)))).toString();
-                jae.setComment(comment);
-            }
-        }
-
         if (entry instanceof ZipArchiveEntry zae) {
-            final byte[] bytComment = Arrays.stream(zae.getExtraFields())
-                                            .filter(UnicodeCommentExtraField.class::isInstance)
-                                            .findFirst()
-                                            .get()
-                                            .getLocalFileDataData();
+            try {
+                final byte[] bytComment = Arrays.stream(zae.getExtraFields())
+                                                .filter(UnicodeCommentExtraField.class::isInstance)
+                                                .findFirst()
+                                                .get()
+                                                .getLocalFileDataData();
 
-            if (bytComment.length > 5) {
-                String comment = StandardCharsets.UTF_8.decode(ByteBuffer.wrap((Arrays.copyOfRange(bytComment, 5,
-                                                                                                   bytComment.length)))).toString();
-                zae.setComment(comment);
-            }
+                if (bytComment.length > 5) {
+                    String comment = StandardCharsets.UTF_8.decode(ByteBuffer.wrap((Arrays.copyOfRange(bytComment, 5,
+                                                                                                       bytComment.length))))
+                                                           .toString();
+                    zae.setComment(comment);
+                }
+            } catch (Exception e) {}
         }
     }
 

--- a/pearl-zip-archive-acc/src/test/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteServiceTestCore.java
+++ b/pearl-zip-archive-acc/src/test/java/com/ntak/pearlzip/archive/acc/pub/CommonsCompressArchiveWriteServiceTestCore.java
@@ -266,7 +266,7 @@ public abstract class CommonsCompressArchiveWriteServiceTestCore {
 
         Assertions.assertTrue(Files.exists(archive), "Archive was not created");
         final byte[] bytes = Files.readAllBytes(archive);
-        Assertions.assertEquals(22, bytes.length, "File failed to create in the expected manner");
+        Assertions.assertEquals(382, bytes.length, "File failed to create in the expected manner");
 
         // Zip magic number
         Assertions.assertEquals((byte)0x50, bytes[0], "first byte");

--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/ArchiveService.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/ArchiveService.java
@@ -6,9 +6,7 @@ package com.ntak.pearlzip.archive.pub;
 import javafx.scene.Node;
 import javafx.util.Pair;
 
-import java.util.Optional;
-import java.util.ResourceBundle;
-import java.util.Set;
+import java.util.*;
 
 import static com.ntak.pearlzip.archive.constants.ConfigurationConstants.CNS_COM_BUS_FACTORY;
 import static com.ntak.pearlzip.archive.constants.LoggingConstants.LOG_ARCHIVE_SERVICE_COM_BUS_INIT_ERROR;
@@ -20,6 +18,10 @@ import static com.ntak.pearlzip.archive.util.LoggingUtil.resolveTextKey;
  *  @author Aashutos Kakshepati
  */
 public interface ArchiveService {
+
+    String OPEN_ARCHIVE_OPTIONS = "pearlzip.pane.open-archive-options";
+    String OPTIONS = "pearlzip.pane.options";
+    String CREATE_OPTIONS = "pearlzip.pane.create-options";
 
     CommunicationBus DEFAULT_BUS = initializeBus();
 
@@ -133,4 +135,30 @@ public interface ArchiveService {
      *   or empty if not required
      */
     default Optional<ResourceBundle> getResourceBundle() { return Optional.empty(); }
+
+    default Optional<FXForm> getFXFormByIdentifier(String name, Object... parameters) { return Optional.empty();}
+
+    class FXForm {
+        private final String name;
+        private final Node content;
+        private final Map<String,Object> configuration;
+
+        public FXForm(String name, Node content, Map<String,Object> configuration) {
+            this.name = name;
+            this.content = content;
+            this.configuration = configuration;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Node getContent() {
+            return content;
+        }
+
+        public Map<String,Object> getConfiguration() {
+            return Collections.unmodifiableMap(configuration);
+        }
+    }
 }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
@@ -13,7 +13,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
-import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.Dragboard;
@@ -294,16 +293,17 @@ public class FrmOptionsController {
         for (ArchiveService service : services.stream()
                                               .map(Pair::getValue)
                                               .collect(Collectors.toList())) {
-            if ((service.getOptionsPane()).isPresent()) {
-                Pair<String,Node> tab = service.getOptionsPane()
-                                               .get();
+
+            if (service.getFXFormByIdentifier(ArchiveService.OPTIONS).isPresent()) {
+                ArchiveService.FXForm tab = service.getFXFormByIdentifier(ArchiveService.OPTIONS)
+                                                   .get();
 
                 Tab customTab = new Tab();
-                customTab.setText(tab.getKey());
+                customTab.setText(tab.getName());
                 customTab.setId(String.format(PATTERN_FXID_OPTIONS,
                                               service.getClass()
                                                      .getCanonicalName()));
-                customTab.setContent(tab.getValue());
+                customTab.setContent(tab.getContent());
                 tabPaneOptions.getTabs()
                               .add(customTab);
             }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/MacZipLauncher.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/MacZipLauncher.java
@@ -85,10 +85,11 @@ public class MacZipLauncher extends Application {
                                                                                                      writeService);
 
                                                // Generates PreOpen dialog, if required
-                                               Optional<Node> optNode;
-                                               if ((optNode = readService.getOpenArchiveOptionsPane(fxArchiveInfo.getArchiveInfo())).isPresent()) {
+                                               Optional<ArchiveService.FXForm> optNode;
+                                               if ((optNode = readService.getFXFormByIdentifier(ArchiveService.OPEN_ARCHIVE_OPTIONS,
+                                                                                                fxArchiveInfo.getArchiveInfo())).isPresent()) {
                                                    Stage preOpenStage = new Stage();
-                                                   Node root = optNode.get();
+                                                   Node root = optNode.get().getContent();
                                                    JFXUtil.loadPreOpenDialog(preOpenStage, root);
 
                                                    Pair<AtomicBoolean,String> result = (Pair<AtomicBoolean,String>) root.getUserData();
@@ -257,13 +258,14 @@ public class MacZipLauncher extends Application {
                                           readService, writeService);
 
         // Generates PreOpen dialog, if required
-        Optional<Node> optNode;
-        if ((optNode = readService.getOpenArchiveOptionsPane(fxArchiveInfo.getArchiveInfo())).isPresent()) {
+        Optional<ArchiveService.FXForm> optFXForm;
+        if ((optFXForm = readService.getFXFormByIdentifier(ArchiveService.OPEN_ARCHIVE_OPTIONS,
+                                                         fxArchiveInfo.getArchiveInfo())).isPresent()) {
             stage.initStyle(StageStyle.TRANSPARENT);
             stage.show();
 
             Stage preOpenStage = new Stage();
-            Node root = optNode.get();
+            Node root = optFXForm.get().getContent();
             JFXUtil.loadPreOpenDialog(preOpenStage, root);
 
             Pair<AtomicBoolean,String> result = (Pair<AtomicBoolean,String>) root.getUserData();

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
@@ -3,10 +3,7 @@
  */
 package com.ntak.pearlzip.ui.util;
 
-import com.ntak.pearlzip.archive.pub.ArchiveInfo;
-import com.ntak.pearlzip.archive.pub.ArchiveReadService;
-import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
-import com.ntak.pearlzip.archive.pub.FileInfo;
+import com.ntak.pearlzip.archive.pub.*;
 import com.ntak.pearlzip.ui.constants.ZipConstants;
 import com.ntak.pearlzip.ui.model.FXArchiveInfo;
 import com.ntak.pearlzip.ui.model.ZipState;
@@ -296,9 +293,10 @@ public class ArchiveUtil {
     }
 
     public static void checkPreOpenDialog(ArchiveReadService readService, ArchiveInfo archiveInfo) throws InterruptedException, IOException {
-        Optional<Node> optNode;
-        if ((optNode = readService.getOpenArchiveOptionsPane(archiveInfo)).isPresent()) {
-            Node root = optNode.get();
+        Optional<ArchiveService.FXForm> optFXForm;
+        if ((optFXForm = readService.getFXFormByIdentifier(ArchiveService.OPEN_ARCHIVE_OPTIONS,
+                                                           archiveInfo)).isPresent()) {
+            Node root = optFXForm.get().getContent();
 
             CountDownLatch latch = new CountDownLatch(1);
             JFXUtil.runLater(() -> {

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallbackTest.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/cell/CommentsHighlightFileInfoCellCallbackTest.java
@@ -48,7 +48,11 @@ public class CommentsHighlightFileInfoCellCallbackTest {
                 latch.countDown();
             });
         } catch (Exception e) {
-            latch.countDown();
+            Platform.runLater(() -> {
+                cell = new TableCell<>();
+                row = new TableRow<>();
+                latch.countDown();
+            });
         } finally {
             latch.await();
 

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AddToArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AddToArchiveTestFX.java
@@ -872,15 +872,19 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
                                            "test.tar").get();
             doubleClickOn(rowGZTar);
             sleep(250, MILLISECONDS);
-            doubleClickOn(rowGZTar);
-            sleep(250, MILLISECONDS);
 
             // 2) temp.tar - Check to ensure tar is present
+            nestedGZArchiveInfo = lookupArchiveInfo("test.tar").get();
             Assertions.assertTrue(nestedGZArchiveInfo.getFiles()
                                                      .stream()
                                                      .anyMatch(f -> f.getFileName()
                                                                      .contains("empty-archive.tar")),
                                   "Tar archive is not present");
+            rowTar = simTraversalArchive(this,
+                                         nestedGZArchiveInfo.getArchivePath(),
+                                         "#fileContentsView",
+                                         (r) -> {},
+                                         "empty-archive.tar").get();
             doubleClickOn(rowTar);
 
             // 3) empty-archive.tar - Check to ensure temp file is persisted
@@ -970,6 +974,7 @@ public class AddToArchiveTestFX extends AbstractPearlZipTestFX {
             clickOn(archiveInfo.getController().get().getFileContentsView(), MouseButton.SECONDARY)
                .clickOn("#mnuAddDir");
             NativeFileChooserUtil.chooseFile(PLATFORM, this, emptyDirFoo);
+            sleep(250,MILLISECONDS);
             simAddFolder(this, emptyDirBar);
 
             // Add file boom

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/CompressorArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/CompressorArchiveTestFX.java
@@ -575,6 +575,7 @@ public class CompressorArchiveTestFX extends AbstractPearlZipTestFX {
                                      .get();
         sleep(250, MILLISECONDS);
         doubleClickOn(row);
+        sleep(250, MILLISECONDS);
 
         // Check window menu (incl. active window)
         Assertions.assertEquals(2,


### PR DESCRIPTION
PZ-166:
+ CommonsCompressArchiveWriteService - Wrapped comments logic with exception handling to ensure if no comment block exists, files are buffered through

PZ-161:
+ ArchiveService - Added Constant declarations, FXForm object and interface method to aid with generic retrieval of JavaFX Node objects for PearlZip hooks
+ FrmNewController, FrmNewSingleFileController - Use FXForm object to represent Custom New tab. The tab will be uniquely identified by the service implementation class type. New tab is identified by active write service and does not show all tabs
+ FrmOptionsController - Use FXForm object to represent Custom New tab
+ FrmOptionsController - Use FXForm object to represent Custom New tab
+ TestFX updates to ensure runs as expected

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>