### PR TITLE
PZ-184,PZ-185 | Clicking on folder with extension zip should open folder and not try to attempt interpretation as a zip file; Remove duplication of save dialog title in BtnCreateEventHandler

### DIFF
--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnCreateEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/BtnCreateEventHandler.java
@@ -51,8 +51,7 @@ public class BtnCreateEventHandler implements EventHandler<MouseEvent> {
 
                 FileChooser saveDialog = new FileChooser();
                 // TITLE: Save archive to location...
-                saveDialog.setTitle(TITLE_TARGET_ARCHIVE_LOCATION);
-                saveDialog.setTitle(resolveTextKey(TITLE_SAVE_ARCHIVE_PATTERN));
+                saveDialog.setTitle(resolveTextKey(TITLE_TARGET_ARCHIVE_LOCATION));
                 saveDialog.setInitialFileName("UntitledArchive");
                 File newArchive = saveDialog.showSaveDialog(dlgStage);
                 if (newArchive != null) {

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/event/handler/FileInfoRowEventHandler.java
@@ -103,7 +103,7 @@ public class FileInfoRowEventHandler implements  EventHandler<MouseEvent> {
                                                      selectedFile
                                                              .getFileName().toString());
 
-                if (ZipState.supportedReadArchives().stream().anyMatch(e -> clickedRow.getFileName().endsWith(String.format(".%s", e)))) {
+                if (!clickedRow.isFolder() && ZipState.supportedReadArchives().stream().anyMatch(e -> clickedRow.getFileName().endsWith(String.format(".%s", e)))) {
                     JFXUtil.executeBackgroundProcess(sessionId, thisStage,
                                                      ()-> {
                                                          JFXUtil.runLater(() -> row.setDisable(true));


### PR DESCRIPTION
PZ-184:
+ Updated event handler FileInfoRowEventHandler to factor in folder checks when determining if an entry is an archive or not.

PZ-185:
+ Updated save dialog title string and removed duplicate call in BtnCreateEventHandler.

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>