### PR TITLE
PZ-193 | Updated TestFX cases as part of release 0.0.0.3 changes

### DIFF
--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -348,6 +348,7 @@ public class ZipConstants {
     public static ErrorAlertConsumer ERROR_ALERT_CONSUMER;
     public static Path RUNTIME_MODULE_PATH;
     public static Set<String> RK_KEYS;
+    public static Runnable POST_PZAX_COMPLETION_CALLBACK = () -> System.exit(0);
 
     public static final CountDownLatch APP_LATCH = new CountDownLatch(1);
     public static final ReadWriteLock LCK_CLEAR_CACHE = new ReentrantReadWriteLock(true);

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ArchiveUtil.java
@@ -487,7 +487,7 @@ public class ArchiveUtil {
             ModuleUtil.loadModuleFromExtensionPackage(Paths.get(f));
         } else {
             if (Stage.getWindows().size() == 0) {
-                JFXUtil.runLater(() -> System.exit(0));
+                JFXUtil.runLater(POST_PZAX_COMPLETION_CALLBACK);
             }
         }
     }

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ModuleUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/ModuleUtil.java
@@ -276,7 +276,7 @@ public class ModuleUtil {
         } finally {
             deleteDirectory(tempDir, (b) -> false);
             if (Stage.getWindows().size() == 0) {
-                JFXUtil.runLater(() -> System.exit(0));
+                JFXUtil.runLater(POST_PZAX_COMPLETION_CALLBACK);
             }
         }
     }

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AboutTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AboutTestFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.testfx;
 
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -61,7 +62,10 @@ public class AboutTestFX extends AbstractPearlZipTestFX {
         Assertions.assertEquals("PearlZip", lblAppName.getText(), "Application Name did not match");
         Assertions.assertTrue(lblVersion.getText().matches(".*\\d\\.\\d\\.\\d\\.\\d.*"),
                               "Application version did not match");
-        Assertions.assertEquals("\u00A9 2021 92AK\nProgram written by Aashutos Kakshepati", lblCopyright.getText(), "Copyright did not match");
+        Assertions.assertEquals(String.format("\u00A9 %s 92AK\nProgram written by Aashutos Kakshepati",
+                                              LocalDate.now().getYear()),
+                                lblCopyright.getText(),
+                                "Copyright did not match");
         Assertions.assertEquals("https://pearlzip.92ak.co.uk", lblWeblink.getText(), "Weblink did not match");
         Assertions.assertEquals("BSD 3-Clause Open-source Licensed Software. Click dialog to close.", lblGeneral.getText(), "General text did not match");
 

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.testfx;
 
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static com.ntak.pearlzip.archive.constants.ArchiveConstants.WORKING_APPLICATION_SETTINGS;
 import static com.ntak.pearlzip.ui.UITestSuite.clearDirectory;
 import static com.ntak.pearlzip.ui.constants.ZipConstants.*;
 import static com.ntak.pearlzip.ui.util.PearlZipFXUtil.lookupArchiveInfo;
@@ -419,7 +420,7 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
         try {
             this.clickOn(Point2D.ZERO.add(160, 10))
                 .clickOn(Point2D.ZERO.add(160, 30));
-
+            WORKING_APPLICATION_SETTINGS.setProperty("configuration.ntak.pearl-zip.default-format","zip");
             ComboBox<String> combo = lookup("#comboDefaultFormat").queryAs(ComboBox.class);
             FormUtil.selectComboBoxEntry(this, combo, "tar");
 

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/TestArchiveTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/TestArchiveTestFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.testfx;
 
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import static com.ntak.pearlzip.ui.util.PearlZipFXUtil.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -272,17 +273,22 @@ public class TestArchiveTestFX extends AbstractPearlZipTestFX {
     ////////////////////////////////////////////////////////////////////////////////
 
     @Test
-    @DisplayName("Test: test invalid xz archive returns success alert")
-    public void testFX_testInvalidXZArchive_Alert() {
+    @DisplayName("Test: test invalid xz archive returns failure alert")
+    public void testFX_testInvalidXZArchive_Alert() throws IOException {
         final String archiveFormat = "tar.xz";
+        final Path tempDir = Files.createTempDirectory("pz");
         final String archiveName = String.format("broken.%s", archiveFormat);
-
-        final Path archive = Paths.get("src",  "test", "resources", archiveName).toAbsolutePath();
+        final Path srcArchive = Paths.get("src",  "test", "resources", "test.tar.xz").toAbsolutePath();
+        final Path targetArchive = Paths.get(tempDir.toAbsolutePath().toString(), archiveName).toAbsolutePath();
+        Files.copy(srcArchive,targetArchive);
 
         // Open archive...
-        simOpenArchive(this, archive, true, false);
+        simOpenArchive(this, targetArchive, true, false);
 
         // Test archive
+        Files.deleteIfExists(targetArchive);
+        Files.write(targetArchive, new byte[]{0,0,0,0}, StandardOpenOption.CREATE_NEW);
+        sleep(1000, MILLISECONDS);
         simTestArchive(this);
 
         // Interrogate alert dialog

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/util/PearlZipFXUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.util;
 
@@ -434,7 +434,7 @@ public class PearlZipFXUtil {
             List<ArchiveReadService> readServices, Path initialFile) throws IOException, TimeoutException {
 
         APP = Mockito.mock(PearlZipApplication.class);
-
+        POST_PZAX_COMPLETION_CALLBACK = ()->{};
         // Set up global constants
         ZipConstants.PRIMARY_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
         ZipConstants.RECENT_FILE = Paths.get(System.getProperty("user.home"), ".pz", "rf");
@@ -442,6 +442,14 @@ public class PearlZipFXUtil {
         String version = System.getProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
 
         APPLICATION_SETTINGS_FILE = Paths.get(System.getProperty("user.home"), ".pz", "application.properties");
+        RK_KEYS = new HashSet<>();
+        RK_KEYS.add("configuration.ntak.pearl-zip.app-name");
+        RK_KEYS.add("configuration.ntak.pearl-zip.version");
+        RK_KEYS.add("configuration.ntak.pearl-zip.copyright");
+        RK_KEYS.add("configuration.ntak.pearl-zip.weblink");
+        RK_KEYS.add("configuration.ntak.pearl-zip.license-location");
+        RK_KEYS.add("configuration.ntak.pearl-zip.license-override-location");
+
         initialiseApplicationSettings();
 
         SETTINGS_FILE = Paths.get(System.getProperty("user.home"), ".pz", "settings.properties");


### PR DESCRIPTION
+ Updated PZAX close callback to aid with TestFX execution
+ AboutTestFX - Updated copyright check to match current year
+ OptionsTestFX - Set configuration to default/expected setting prior to execution of test case
+ TestArchiveTestFX - Handle open validity check to ensure the test button can be tested
+ PearlZipFXUtil - Set default PZAX close callback (NOP)

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>