### PR TITLE
PZ-195,PZ-197 | Notification window should not be resizable; Decouple UI from license and provider implementation dependencies

### DIFF
--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ConfigurationConstants.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/constants/ConfigurationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.archive.constants;
 
@@ -10,6 +10,7 @@ package com.ntak.pearlzip.archive.constants;
 public class ConfigurationConstants {
     public static final String CNS_NTAK_PEARL_ZIP_ICON_FILE = "configuration.ntak.pearl-zip.icon.file";
     public static final String CNS_NTAK_PEARL_ZIP_ICON_FOLDER = "configuration.ntak.pearl-zip.icon.folder";
+    public static final String CNS_NTAK_PEARL_ZIP_LICENSE_SERVICE_CANONICAL_NAME = "configuration.ntak.pearl-zip.license-service-canonical-name";
     public static final String CNS_LOCALE_LANG = "configuration.ntak.pearl-zip.locale.lang";
     public static final String CNS_LOCALE_COUNTRY = "configuration.ntak.pearl-zip.locale.country";
     public static final String CNS_LOCALE_VARIANT = "configuration.ntak.pearl-zip.locale.variant";

--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/model/LicenseInfo.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/model/LicenseInfo.java
@@ -1,7 +1,7 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
-package com.ntak.pearlzip.license.model;
+package com.ntak.pearlzip.archive.model;
 
 import java.util.Objects;
 

--- a/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/LicenseService.java
+++ b/pearl-zip-archive/src/main/java/com/ntak/pearlzip/archive/pub/LicenseService.java
@@ -1,9 +1,9 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
-package com.ntak.pearlzip.license.pub;
+package com.ntak.pearlzip.archive.pub;
 
-import com.ntak.pearlzip.license.model.LicenseInfo;
+import com.ntak.pearlzip.archive.model.LicenseInfo;
 
 import java.util.Map;
 

--- a/pearl-zip-archive/src/main/java/module-info.java
+++ b/pearl-zip-archive/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module com.ntak.pearlzip.archive {
     exports com.ntak.pearlzip.archive.util;
     exports com.ntak.pearlzip.archive.constants;
     exports com.ntak.pearlzip.archive.pub;
+    exports com.ntak.pearlzip.archive.model;
 
     ////////////////////
     ///// Requires /////

--- a/pearl-zip-license/src/main/java/com/ntak/pearlzip/license/pub/PearlZipLicenseService.java
+++ b/pearl-zip-license/src/main/java/com/ntak/pearlzip/license/pub/PearlZipLicenseService.java
@@ -1,10 +1,11 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.license.pub;
 
+import com.ntak.pearlzip.archive.model.LicenseInfo;
+import com.ntak.pearlzip.archive.pub.LicenseService;
 import com.ntak.pearlzip.license.constants.LicenseConstants;
-import com.ntak.pearlzip.license.model.LicenseInfo;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.w3c.dom.Document;

--- a/pearl-zip-license/src/main/java/module-info.java
+++ b/pearl-zip-license/src/main/java/module-info.java
@@ -1,15 +1,14 @@
-import com.ntak.pearlzip.license.pub.LicenseService;
+import com.ntak.pearlzip.archive.pub.LicenseService;
 import com.ntak.pearlzip.license.pub.PearlZipLicenseService;
 
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 /**
  *  Provides license information of core dependencies of the Pearl Zip project.
  */
 module com.ntak.pearlzip.license {
     exports com.ntak.pearlzip.license.pub;
-    exports com.ntak.pearlzip.license.model;
 
     provides LicenseService with PearlZipLicenseService;
 

--- a/pearl-zip-license/src/test/java/com/ntak/pearlzip/license/pub/PearlZipLicenseServiceTest.java
+++ b/pearl-zip-license/src/test/java/com/ntak/pearlzip/license/pub/PearlZipLicenseServiceTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.license.pub;
 
-import com.ntak.pearlzip.license.model.LicenseInfo;
+import com.ntak.pearlzip.archive.model.LicenseInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/pearl-zip-ui/pom.xml
+++ b/pearl-zip-ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2021 92AK
+  ~ Copyright © 2022 92AK
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -30,6 +30,24 @@
     </licenses>
 
     <dependencies>
+        <dependency>
+            <groupId>com.ntak</groupId>
+            <artifactId>pearl-zip-archive-acc</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ntak</groupId>
+            <artifactId>pearl-zip-archive-szjb</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ntak</groupId>
+            <artifactId>pearl-zip-license</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.ntak</groupId>
             <artifactId>ntak-testfx-util</artifactId>
@@ -78,24 +96,6 @@
             <version>16.02-2.01</version>
         </dependency>
         <dependency>
-            <groupId>com.ntak</groupId>
-            <artifactId>pearl-zip-archive-szjb</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ntak</groupId>
-            <artifactId>pearl-zip-license</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ntak</groupId>
-            <artifactId>pearl-zip-archive-acc</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.oracle.jdbc.database</groupId>
             <artifactId>ojdbc11</artifactId>
             <version>21.4.0.0.1</version>
@@ -115,6 +115,21 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*TestSuite.class</include>
+                    </includes>
+                    <argLine>
+                        --add-exports com.ntak.pearlzip.archive.acc/com.ntak.pearlzip.archive.acc.pub=com.ntak.pearlzip.ui
+                        --add-exports com.ntak.pearlzip.archive.szjb/com.ntak.pearlzip.archive.szjb.pub=com.ntak.pearlzip.ui
+                        --illegal-access=permit
+                    </argLine>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
@@ -173,6 +188,8 @@
                     <source>17</source>
                     <target>17</target>
                     <compilerArgs>
+                        <compilerArg>--add-opens</compilerArg>
+                        <compilerArg>com.ntak.pearlzip.license/com.ntak.pearlzip.license.pub.PearlZipLicenseService=com.ntak.pearlzip.ui</compilerArg>
                         <compilerArg>--add-exports</compilerArg>
                         <compilerArg>nsmenufx/de.jangassen.platform.mac=com.ntak.pearlzip.ui</compilerArg>
                         <compilerArg>--add-exports</compilerArg>

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
@@ -1,12 +1,12 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.model;
 
+import com.ntak.pearlzip.archive.model.LicenseInfo;
 import com.ntak.pearlzip.archive.pub.ArchiveReadService;
 import com.ntak.pearlzip.archive.pub.ArchiveService;
 import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
-import com.ntak.pearlzip.license.model.LicenseInfo;
 import javafx.scene.control.ContextMenu;
 import org.apache.logging.log4j.util.Strings;
 

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmLicenseOverviewController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmLicenseOverviewController.java
@@ -1,10 +1,10 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.pub;
 
+import com.ntak.pearlzip.archive.model.LicenseInfo;
 import com.ntak.pearlzip.archive.util.LoggingUtil;
-import com.ntak.pearlzip.license.model.LicenseInfo;
 import com.ntak.pearlzip.ui.model.ZipState;
 import com.ntak.pearlzip.ui.util.JFXUtil;
 import javafx.beans.property.SimpleStringProperty;

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/ZipLauncher.java
@@ -5,9 +5,8 @@ package com.ntak.pearlzip.ui.pub;
 
 import com.ntak.pearlzip.archive.constants.ConfigurationConstants;
 import com.ntak.pearlzip.archive.constants.LoggingConstants;
+import com.ntak.pearlzip.archive.pub.LicenseService;
 import com.ntak.pearlzip.archive.util.LoggingUtil;
-import com.ntak.pearlzip.license.pub.LicenseService;
-import com.ntak.pearlzip.license.pub.PearlZipLicenseService;
 import com.ntak.pearlzip.ui.constants.ZipConstants;
 import com.ntak.pearlzip.ui.mac.MacPearlZipApplication;
 import com.ntak.pearlzip.ui.model.ZipState;
@@ -79,7 +78,7 @@ public class ZipLauncher {
        Runtime.getRuntime().exit(0);
     }
 
-    public static void initialize() throws IOException {
+    public static void initialize() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
         // Load bootstrap properties
         Properties props = initialiseBootstrapProperties();
 
@@ -127,9 +126,17 @@ public class ZipLauncher {
                                               Locale.getDefault());
 
         // Load License Declarations
-        LicenseService licenseService = new PearlZipLicenseService();
-        licenseService.retrieveDeclaredLicenses()
-                      .forEach(ZipState::addLicenseDeclaration);
+        try {
+            LicenseService licenseService = (LicenseService) Class.forName(System.getProperty(
+                                                                          CNS_NTAK_PEARL_ZIP_LICENSE_SERVICE_CANONICAL_NAME,
+                                                                          "com.ntak.pearlzip.license.pub.PearlZipLicenseService"))
+                                                                  .getDeclaredConstructor()
+                                                                  .newInstance();
+            licenseService.retrieveDeclaredLicenses()
+                          .forEach(ZipState::addLicenseDeclaration);
+        } catch (Exception e) {
+
+        }
 
         ////////////////////////////////////////////
         ///// KeyStore Setup //////////////////////

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/util/JFXUtil.java
@@ -326,6 +326,7 @@ public class JFXUtil {
             Parent root = loader.load();
             notificationStage.setScene(new Scene(root));
 
+            notificationStage.setResizable(false);
             notificationStage.setAlwaysOnTop(true);
             notificationStage.toFront();
             notificationStage.show();

--- a/pearl-zip-ui/src/main/java/module-info.java
+++ b/pearl-zip-ui/src/main/java/module-info.java
@@ -1,8 +1,9 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 import com.ntak.pearlzip.archive.pub.ArchiveReadService;
 import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
+import com.ntak.pearlzip.archive.pub.LicenseService;
 
 /**
  *  General UI/front-end JavaFX code for the Pearl Zip application.
@@ -25,11 +26,6 @@ module com.ntak.pearlzip.ui {
     // PearlZip dependencies
     requires com.ntak.pearlzip.archive;
     requires com.ntak.pearlzip.lang.enGB;
-    requires com.ntak.pearlzip.archive.szjb;
-    requires com.ntak.pearlzip.archive.acc;
-    requires com.ntak.pearlzip.license;
-
-    requires sevenzipjbinding;
 
     opens com.ntak.pearlzip.ui.pub;
     exports com.ntak.pearlzip.ui.constants;
@@ -47,4 +43,5 @@ module com.ntak.pearlzip.ui {
     // SPI Definition
     uses ArchiveWriteService;
     uses ArchiveReadService;
+    uses LicenseService;
 }

--- a/pearl-zip-ui/src/main/resources/application.properties
+++ b/pearl-zip-ui/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 92AK
+# Copyright © 2022 92AK
 #
 
 configuration.ntak.pearl-zip.provider.priority.enabled.com.ntak.pearlzip.archive.szjb.pub.SevenZipArchiveService=true
@@ -17,6 +17,7 @@ configuration.ntak.pearl-zip.commit-hash=:: HASH ::
 configuration.ntak.pearl-zip.concurrency.lock-poll-timeout=100
 configuration.ntak.pearl-zip.default-format=zip
 configuration.ntak.pearl-zip.launcher-canonical-name=com.ntak.pearlzip.ui.mac.MacPearlZipApplication
+configuration.ntak.pearl-zip.license-service-canonical-name=com.ntak.pearlzip.license.pub.PearlZipLicenseService
 configuration.ntak.pearl-zip.jdbc.url=jdbc:oracle:thin:@(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.uk-london-1.oraclecloud.com))(connect_data=(service_name=ga9b5a5185cc7a2_ntaknotify_low.adb.oraclecloud.com))(security=(ssl_server_cert_dn=\"CN=adwc.eucom-central-1.oraclecloud.com, OU=Oracle BMCS FRANKFURT, O=Oracle Corporation, L=Redwood City, ST=California, C=US\")))
 configuration.ntak.pearl-zip.jdbc.user=APP
 configuration.ntak.pearl-zip.jdbc.password=PZAUser0003Plus

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/model/ZipStateTest.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/model/ZipStateTest.java
@@ -1,13 +1,13 @@
 /*
- * Copyright © 2021 92AK
+ * Copyright © 2022 92AK
  */
 package com.ntak.pearlzip.ui.model;
 
+import com.ntak.pearlzip.archive.model.LicenseInfo;
 import com.ntak.pearlzip.archive.pub.ArchiveInfo;
 import com.ntak.pearlzip.archive.pub.ArchiveReadService;
 import com.ntak.pearlzip.archive.pub.ArchiveWriteService;
 import com.ntak.pearlzip.archive.pub.FileInfo;
-import com.ntak.pearlzip.license.model.LicenseInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AboutTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/AboutTestFX.java
@@ -3,8 +3,8 @@
  */
 package com.ntak.pearlzip.ui.testfx;
 
-import com.ntak.pearlzip.license.model.LicenseInfo;
-import com.ntak.pearlzip.license.pub.LicenseService;
+import com.ntak.pearlzip.archive.model.LicenseInfo;
+import com.ntak.pearlzip.archive.pub.LicenseService;
 import com.ntak.pearlzip.license.pub.PearlZipLicenseService;
 import com.ntak.pearlzip.ui.model.ZipState;
 import com.ntak.pearlzip.ui.util.AbstractPearlZipTestFX;


### PR DESCRIPTION
PZ-197:
+ LicenseInfo, LicenseService model and interface contract respectively have been moved to common archive package
+ ZipState, FrmLicenseOverviewControllerm, ZipLauncher are decoupled from the license package implementation via the use of interfaces and archive package common objects. Implementation is derived via reflection.
+ Removed explicit dependencies on szjb,acc packages as service loader retrieves them.

PZ-195:
+ Notification stage is not resizeable.

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>