### PR TITLE
PZ-226 | Setting language configuration to a non-existent language should yield default en-GB language pack and start up (rather than fail to start up silently)

### DIFF
--- a/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
+++ b/pearl-zip-lang-pack-en-GB/src/main/resources/pearlzip_en_GB.properties
@@ -87,6 +87,8 @@ logging.ntak.pearl-zip.theme-not-exist=Theme %s does not exist.
 logging.ntak.pearl-zip.create-directory=Creating directory %s...
 logging.ntak.pearl-zip.dir-extract-complete=Extraction of directory %s has completed.
 
+logging.ntak.pearl-zip.missing-keys-lang-pack=Language pack for Locale: %s have missing keys: %s
+
 ###################################################################################################
 ######################################## TITLE TEXT KEYS ##########################################
 ###################################################################################################

--- a/pearl-zip-lang-pack-fr-FR/src/main/resources/pearlzip_fr_FR.properties
+++ b/pearl-zip-lang-pack-fr-FR/src/main/resources/pearlzip_fr_FR.properties
@@ -87,6 +87,8 @@ logging.ntak.pearl-zip.theme-not-exist=Le thème %s n’existe pas.
 logging.ntak.pearl-zip.create-directory=Création du répertoire %s...
 logging.ntak.pearl-zip.dir-extract-complete=L’extraction du répertoire %s est terminée.
 
+logging.ntak.pearl-zip.missing-keys-lang-pack=Module linguistique pour les paramètres régionaux : %s ont des clés manquantes : %s
+
 ###################################################################################################
 ######################################## TITLE TEXT KEYS ##########################################
 ###################################################################################################
@@ -196,8 +198,8 @@ body.ntak.pearl-zip.file-not-exist=Le fichier choisi %s n’existe pas. Il sera 
 
 title.ntak.pearl-zip.cannot-drop-same-dir=Avertissement: Impossible de déposer à cet emplacement
 title.ntak.pearl-zip.cannot-paste-same-dir=vertissement: Impossible de coller à cet emplacement
-header.ntak.pearl-zip.cannot-paste-same-dir=Annulation de la migration
-body.ntak.pearl-zip.cannot-paste-same-dir=La migration a été annulée car l’emplacement de destination est identique à l’emplacement source. Il s’agit d’un processus non pris en charge.
+header.ntak.pearl-zip.issue-same-dir=Annulation de la migration
+body.ntak.pearl-zip.issue-same-dir=La migration a été annulée car l’emplacement de destination est identique à l’emplacement source. Il s’agit d’un processus non pris en charge.
 
 title.ntak.pearl-zip.file-not-unique=Avertissement: Fichier sélectionné non unique
 header.ntak.pearl-zip.file-not-unique=Le nom de fichier choisi existe déjà

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/constants/ZipConstants.java
@@ -103,6 +103,7 @@ public class ZipConstants {
     public static final String LOG_LOADING_MODULE = "logging.ntak.pearl-zip.loading-module";
     public static final String LOG_READ_SERVICES_IDENTIFIED = "logging.ntak.pearl-zip.read-services-identified";
     public static final String LOG_WRITE_SERVICES_IDENTIFIED = "logging.ntak.pearl-zip.write-services-identified";
+    public static final String LOG_MISSING_KEYS_LANG_PACK = "logging.ntak.pearl-zip.missing-keys-lang-pack";
 
     public static final String LOG_ARCHIVE_LOCKED = "logging.ntak.pearl-zip.archive-locked";
     public static final String TITLE_ARCHIVE_LOCKED = "title.ntak.pearl-zip.archive-locked";
@@ -401,6 +402,7 @@ public class ZipConstants {
     public static final ReadWriteLock LCK_CLEAR_CACHE = new ReentrantReadWriteLock(true);
 
     public static final String WINDOW_FOCUS_SYMBOL = " • ";
+    public static final String CNS_PROP_HEADER = "PearlZip Application Settings File Generated @ %s";
 
     public static final String MANIFEST_FILE_NAME = "MF";
     public static final String KEY_MANIFEST_DELETED= "remove-pattern";

--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/pub/FrmOptionsController.java
@@ -550,7 +550,7 @@ public class FrmOptionsController {
             synchronized(WORKING_APPLICATION_SETTINGS) {
                 try(OutputStream settingsOutputStream = Files.newOutputStream(APPLICATION_SETTINGS_FILE)) {
                     WORKING_APPLICATION_SETTINGS.store(settingsOutputStream,
-                                                       String.format("PearlZip Application Settings File Generated @ %s",
+                                                       String.format(CNS_PROP_HEADER,
                                                                      LocalDateTime.now()));
                     // Reloading providers and cached System settings into PearlZip
                     WORKING_APPLICATION_SETTINGS.keySet()

--- a/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
+++ b/pearl-zip-ui/src/test/java/com/ntak/pearlzip/ui/testfx/OptionsTestFX.java
@@ -472,6 +472,9 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
     @Test
     @DisplayName("Test: Change language pack successfully")
     public void testFX_ChangeLanguagePack_Success() throws IOException {
+        System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.4.0");
+        WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.4.0");
+
         //  Back up existing application.properties file
         Path appPropsPath = Paths.get(STORE_ROOT.toAbsolutePath()
                                                 .toString(), "application.properties");
@@ -541,12 +544,19 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                                            .toString(), "manifests", "pearl-zip-lang-pack-fr-CA-0.0.4.0.pzax.MF"));
             Files.deleteIfExists(Paths.get(STORE_ROOT.toAbsolutePath()
                                                      .toString(), "providers", "pearl-zip-lang-pack-fr-CA-0.0.4.0.jar"));
+
+            System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
         }
     }
 
     @Test
     @DisplayName("Test: Install theme, switch theme and uninstall successfully")
     public void testFX_InstallTheme_Success() throws IOException {
+        System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.4.0");
+        WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.4.0");
+
         //  Back up existing application.properties file
         Path appPropsPath = Paths.get(STORE_ROOT.toAbsolutePath()
                                                 .toString(), "application.properties");
@@ -643,6 +653,10 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                                    "Theme manifest not removed");
         } finally {
             Files.move(tempPropsPath, appPropsPath, StandardCopyOption.REPLACE_EXISTING);
+
+            System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
         }
     }
 
@@ -758,6 +772,10 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                                     "Exception message was not as expected");
         } finally {
             Files.move(backupProvidersDir, providersDir, StandardCopyOption.REPLACE_EXISTING);
+
+            System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
         }
     }
 
@@ -795,6 +813,10 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                                   "Exception message was not as expected");
         } finally {
             Files.move(backupProvidersDir, providersDir, StandardCopyOption.REPLACE_EXISTING);
+
+            System.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
+            WORKING_APPLICATION_SETTINGS.setProperty(CNS_NTAK_PEARL_ZIP_VERSION, "0.0.0.0");
         }
     }
 
@@ -833,7 +855,8 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
                 .sleep(250, MILLISECONDS);
 
             Assertions.assertEquals(0,
-                                    Files.list(providersDir).collect(Collectors.toList()).size(),
+                                    (int) Files.list(providersDir)
+                                               .count(),
                                     "Plugins were not removed");
         } finally {
             clearDirectory(providersDir);
@@ -902,9 +925,8 @@ public class OptionsTestFX extends AbstractPearlZipTestFX {
 
                 Set<DialogPane> dialogPanes = lookup(".dialog-pane").queryAllAs(DialogPane.class);
                 Assertions.assertEquals(2,
-                                        Files.list(providersDir)
-                                             .collect(Collectors.toList())
-                                             .size(),
+                                        (int) Files.list(providersDir)
+                                                   .count(),
                                         "Unexpected number of plugins found.");
 
                 dialogPanes.forEach(d -> this.sleep(250, MILLISECONDS)


### PR DESCRIPTION


+ A check is performed to ensure that all log keys are accounted for in the selected language pack compared to the default language pack that comes bundled with the application (en-GB)
+ On issue where no language pack exists (for Locale), the default language (en-GB) is utilised and also will be set to ensure issue is not re-triggered when PearlZip starts the next time
+ Added relevant logging keys

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>