### PR TITLE
PZ-263 | Ensure reading archive files by PearlZip is case insensitive with respect to filename extension

### DIFF
--- a/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
+++ b/pearl-zip-ui/src/main/java/com/ntak/pearlzip/ui/model/ZipState.java
@@ -43,7 +43,7 @@ public class ZipState {
 
     public static Optional<ArchiveReadService> getReadArchiveServiceForFile(String filename) {
         try {
-            String extension = filename.substring(filename.lastIndexOf(".")+1);
+            String extension = filename.substring(filename.lastIndexOf(".")+1).toLowerCase();
             return  Optional.ofNullable(ARCHIVE_READ_MAP.get(extension));
         } catch(Exception e) {
             return Optional.empty();
@@ -52,7 +52,7 @@ public class ZipState {
 
     public static Optional<ArchiveWriteService> getWriteArchiveServiceForFile(String filename) {
         try {
-            String extension = filename.substring(filename.lastIndexOf(".")+1);
+            String extension = filename.substring(filename.lastIndexOf(".")+1).toLowerCase();
             return  Optional.ofNullable(ARCHIVE_WRITE_MAP.get(extension));
         } catch(Exception e) {
             return Optional.empty();


### PR DESCRIPTION
+ Updated utility methods.

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>